### PR TITLE
Remove Spree from the generated license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added `--require spec_helper` to the generated `.rspec`
 
+### Fixed
+
+- Replaced "Spree" with "Solidus" in the license of generated extensions
+
 ## [0.4.1] - 2020-01-15
 
 ### Fixed

--- a/lib/solidus_dev_support/templates/extension/LICENSE
+++ b/lib/solidus_dev_support/templates/extension/LICENSE
@@ -9,7 +9,7 @@ are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-    * Neither the name Spree nor the names of its contributors may be used to
+    * Neither the name Solidus nor the names of its contributors may be used to
       endorse or promote products derived from this software without specific
       prior written permission.
 


### PR DESCRIPTION
Fixes #64.

## Summary

Replaces "Spree" with "Solidus" in the license of generated extensions.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
