### PR TITLE
Require spec_helper automatically in generated extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `--require spec_helper` to the generated `.rspec`
+
 ## [0.4.1] - 2020-01-15
 
 ### Fixed

--- a/lib/solidus_dev_support/templates/extension/rspec
+++ b/lib/solidus_dev_support/templates/extension/rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper


### PR DESCRIPTION
Fixes #62.

## Summary

Requires `spec_helper.rb` via `.rspec` in generated extensions, so that users don't have to `require "spec_helper"` in every spec file.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
