### PR TITLE
Use tags instead of branches for new gem releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Replaced "Spree" with "Solidus" in the license of generated extensions
 
+### Changed
+
+- Updated gem-release to use tags instead of branches for new releases
+
 ## [0.4.1] - 2020-01-15
 
 ### Fixed

--- a/lib/solidus_dev_support/templates/extension/gem_release.yml.tt
+++ b/lib/solidus_dev_support/templates/extension/gem_release.yml.tt
@@ -2,4 +2,4 @@ bump:
   recurse: false
   file: 'lib/<%=file_name%>/version.rb'
   message: Bump <%=class_name%> to %{version}
-  branch: true
+  tag: true


### PR DESCRIPTION
Fixes #67.

## Summary

Reconfigures gem-release to simply tag new releases instead of creating a new branch for each version. 

This is in line with what we've been doing so far: we only use branches in solidusio/solidus where multiple versions are supported at the same time for security reasons. For all other gems we simply release a new patch version instead of backporting bugfixes.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
