### PR TITLE
Make always re-generating the test_app opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added support for a local Gemfile for local development dependencies (e.g. 'pry-debug')
 
+### Changed
+
+- The default rake task no longer re-generates the `test_app` each time it runs.
+  In order to get that behavior back simply call clobber before launching it:
+  `bin/rake clobber default`
+
 ## [0.5.0] - 2020-01-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To install extension-related Rake tasks, add this to your `Rakefile`:
 require 'solidus_dev_support/rake_tasks'
 SolidusDevSupport::RakeTasks.install
 
-task default: %w[extension:test_app extension:specs]
+task default: 'extension:specs'
 ```
 
 (If your extension used the legacy extension Rakefile, then you should completely replace its
@@ -171,7 +171,11 @@ This will provide the following tasks:
 - `extension:test_app`, which generates a dummy app for your extension
 - `extension:specs` (default), which runs the specs for your extension
 
-It also allows you to run `rake` to, respectively, generate a test app and run all tests.
+If your extension requires the `test_app` to be always recreated you can do so by running:
+
+```rb
+bundle exec rake extension:test_app extension:specs
+```
 
 ## Development
 

--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -34,9 +34,15 @@ module SolidusDevSupport
       ::CLOBBER.include test_app_path
 
       namespace :extension do
+        # We need to go back to the gem root since the upstream
+        # extension:test_app changes the working directory to be the dummy app.
         task :test_app do
           Rake::Task['extension:test_app'].invoke
           cd root
+        end
+
+        directory ENV['DUMMY_PATH'] do
+          Rake::Task['extension:test_app'].invoke
         end
       end
     end

--- a/lib/solidus_dev_support/templates/extension/Rakefile
+++ b/lib/solidus_dev_support/templates/extension/Rakefile
@@ -3,4 +3,4 @@
 require 'solidus_dev_support/rake_tasks'
 SolidusDevSupport::RakeTasks.install
 
-task default: %w[extension:test_app extension:specs]
+task default: 'extension:specs'

--- a/lib/solidus_dev_support/templates/extension/bin/setup
+++ b/lib/solidus_dev_support/templates/extension/bin/setup
@@ -5,4 +5,4 @@ set -vx
 
 gem install bundler --conservative
 bundle update
-bundle exec rake extension:test_app
+bundle exec rake clobber


### PR DESCRIPTION
Fixes #69, Partially reverts deb9243c, 93ce7712, and cba90008.

## Summary

- Just remove the test app when running bin/setup, it will be recreated when the default task is ran
- Add instructions on the readme and changelog on how to always recreate the test_app
- Let the rake task recreate the test_app if it's missing when running the specs

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
