### PR TITLE
Support a local Gemfile for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 /spec/reports/
 /tmp/
 /vendor/bundle/
-Gemfile.lock
+/Gemfile.lock
+/Gemfile-local*
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added support for a local Gemfile for local development dependencies (e.g. 'pry-debug')
+
 ## [0.5.0] - 2020-01-16
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,7 @@ group :test do
   gem 'pg'
   gem 'sqlite3'
 end
+
+# Use a local Gemfile to include development dependencies that might not be
+# relevant for the project or for other contributors, e.g.: `gem 'pry-debug'`.
+eval_gemfile 'Gemfile-local' if File.exist? 'Gemfile-local'

--- a/lib/solidus_dev_support/templates/extension/Gemfile
+++ b/lib/solidus_dev_support/templates/extension/Gemfile
@@ -24,3 +24,7 @@ else
 end
 
 gemspec
+
+# Use a local Gemfile to include development dependencies that might not be
+# relevant for the project or for other contributors, e.g.: `gem 'pry-debug'`.
+eval_gemfile 'Gemfile-local' if File.exist? 'Gemfile-local'


### PR DESCRIPTION
Fixes #9.

## Summary

Use a local Gemfile to include development dependencies that might not
be relevant for the project or for other contributors.

The option to have a local gemfile is also added to the root Gemfile.

E.g.: `gem 'pry-debug'`

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
