### PR TITLE
Isolate the root `::Spree` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   In order to get that behavior back simply call clobber before launching it:
   `bin/rake clobber default`
 
+## Fixed
+
+- Fixed generated extensions isolating the wrong namespace
+
 ## [0.5.0] - 2020-01-16
 
 ### Added

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%/engine.rb.tt
@@ -6,7 +6,7 @@ module <%= class_name %>
   class Engine < Rails::Engine
     include SolidusSupport::EngineExtensions::Decorators
 
-    isolate_namespace Spree
+    isolate_namespace ::Spree
 
     engine_name '<%= file_name %>'
 


### PR DESCRIPTION
## Summary

Fixes an issue that would cause generated extensions to isolate the wrong namespace (e.g. `SolidusReviews::Spree` instead of `Spree`) when the extension defines decorators with the new, Zeitwerk-compliant naming convention (e.g. `SolidusReviews::Spree::ProductDecorator`).

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
