### PR TITLE
Add the sandbox rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added support for a local Gemfile for local development dependencies (e.g. 'pry-debug')
+- Added a `bin/sandbox` script to all extension for local development with `bin/rails` support.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ In case of conflicting files, you will be prompted for an action. You can overwr
 the new version, keep the current version or view the diff and only apply the adjustments that make
 sense to you.
 
+### Sandbox app
+
+When developing an extension you will surely need to try it out within a Rails app with Solidus
+installed. Using solidus_dev_support your extension will have a `bin/rails` executable that will
+operate on a _sandbox_ app (creating it if necessary).
+
+The path for the sandbox app is `./sandbox` and `bin/rails` will forward any Rails command
+to `sandbox/bin/rails`.
+
+Example:
+
+```bash
+$ bin/rails server
+=> Booting Puma
+=> Rails 6.0.2.1 application starting in development
+* Listening on tcp://127.0.0.1:3000
+Use Ctrl-C to stop
+```
+
+#### Rebuilding the sandbox app
+
+To rebuild the sandbox app just remove the `./sandbox` folder or run `bin/sandbox`.
+
 ### RSpec helpers
 
 This gem provides some useful helpers for RSpec to setup an extension's test environment easily.

--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -21,6 +21,7 @@ module SolidusDevSupport
 
     def install
       install_test_app_task
+      install_dev_app_task
       install_rspec_task
     end
 
@@ -44,6 +45,14 @@ module SolidusDevSupport
         directory ENV['DUMMY_PATH'] do
           Rake::Task['extension:test_app'].invoke
         end
+      end
+    end
+
+    def install_dev_app_task
+      desc "Creates a sandbox application for simulating the Extension code in a deployed Rails app"
+      task :sandbox do
+        warn "DEPRECATED TASK: This task is here just for parity with solidus, please use bin/sandbox directly."
+        exec("bin/sandbox", gemspec.name)
       end
     end
 

--- a/lib/solidus_dev_support/templates/extension/bin/rails
+++ b/lib/solidus_dev_support/templates/extension/bin/rails
@@ -2,12 +2,15 @@
 
 # frozen_string_literal: true
 
-app_root = 'spec/dummy'
+app_root = 'sandbox'
 
 unless File.exist? "#{app_root}/bin/rails"
-  system "bin/rake", app_root or begin # rubocop:disable Style/AndOr
-    warn "Automatic creation of the dummy app failed"
-    exit 1
+  warn 'Creating the sandbox app...'
+  Dir.chdir "#{__dir__}/.." do
+    system "#{__dir__}/sandbox" or begin # rubocop:disable Style/AndOr
+      warn 'Automatic creation of the sandbox app failed'
+      exit 1
+    end
   end
 end
 

--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -e
+
+case "$DB" in
+postgres|postgresql)
+  RAILSDB="postgresql"
+  ;;
+mysql)
+  RAILSDB="mysql"
+  ;;
+sqlite|'')
+  RAILSDB="sqlite3"
+  ;;
+*)
+  echo "Invalid DB specified: $DB"
+  exit 1
+  ;;
+esac
+
+extension_name="<%= file_name %>"
+
+# Stay away from the bundler env of the containing extension.
+function unbundled {
+  ruby -rbundler -e'b = proc {system *ARGV}; Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&b) : Bundler.with_clean_env(&b)' -- $@
+}
+
+rm -rf ./sandbox
+unbundled bundle exec rails new sandbox --database="$RAILSDB" \
+  --skip-bundle \
+  --skip-git \
+  --skip-keeps \
+  --skip-rc \
+  --skip-spring \
+  --skip-test \
+  --skip-javascript
+
+if [ ! -d "sandbox" ]; then
+  echo 'sandbox rails application failed'
+  exit 1
+fi
+
+cd ./sandbox
+cat <<RUBY >> Gemfile
+
+gem '$extension_name', path: '..'
+gem 'solidus_auth_devise', '>= 2.1.0'
+gem 'rails-i18n'
+gem 'solidus_i18n'
+
+group :test, :development do
+  platforms :mri do
+    gem 'pry-byebug'
+  end
+end
+RUBY
+
+unbundled bundle install --gemfile Gemfile
+
+unbundled bundle exec rake db:drop db:create
+
+unbundled bundle exec rails generate spree:install \
+  --auto-accept \
+  --user_class=Spree::User \
+  --enforce_available_locales=true \
+  $@
+
+unbundled bundle exec rails generate solidus:auth:install
+
+echo
+echo "🚀 Sandbox app successfully created for $extension_name!"
+echo "🚀 This app is intended for test purposes."

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Create extension' do # rubocop:disable Metrics/BlockLength
     check_bundle_install
     check_default_task
     check_run_specs
+    check_sandbox
   end
 
   private
@@ -95,6 +96,19 @@ RSpec.describe 'Create extension' do # rubocop:disable Metrics/BlockLength
       output = sh('bundle exec rspec')
       expect(output).to include('1 example, 0 failures')
       expect(output).to include(ENV['CODECOV_TOKEN'] ? 'Coverage reports upload successfully' : 'Coverage report generated')
+    end
+  end
+
+  def check_sandbox
+    cd(install_path) do
+      command = 'bin/rails runner "puts %{The version of SolidusTestExtension is #{SolidusTestExtension::VERSION}}"'
+      first_run_output = sh(command)
+      expect(first_run_output).to include("Creating the sandbox app...")
+      expect(first_run_output).to include('The version of SolidusTestExtension is 0.0.1')
+
+      second_run_output = sh(command)
+      expect(second_run_output).not_to include("Creating the sandbox app...")
+      expect(second_run_output).to include('The version of SolidusTestExtension is 0.0.1')
     end
   end
 


### PR DESCRIPTION
Fixes #14.

## Summary

Local development should happen on a dedicated app rather than the
test_app (which is most developers are using right now).

Adding a sandbox app with clear instructions will give an easy to use
solution to this problem.

This is a backport of the official Solidus sandbox generator.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
