### PR TITLE
Add a rake binstub to extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added a binstub for `rake` to the extension generator
+
 ## [0.6.0] - 2020-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This will provide the following tasks:
 If your extension requires the `test_app` to be always recreated you can do so by running:
 
 ```rb
-bundle exec rake extension:test_app extension:specs
+bin/rake extension:test_app extension:specs
 ```
 
 ## Development
@@ -183,8 +183,8 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 the tests. You can also run `bin/console` for an interactive prompt that will allow you to
 experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new
-version, update the version number in `version.rb`, and then run `bundle exec rake release`, which
+To install this gem onto your local machine, run `bin/rake install`. To release a new
+version, update the version number in `version.rb`, and then run `bin/rake release`, which
 will create a git tag for the version, push git commits and tags, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
 

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -25,6 +25,7 @@ module SolidusDevSupport
       %w[
         bin/console
         bin/rails
+        bin/rake
         bin/setup
       ].each do |bin|
         template bin, "#{path}/#{bin}"

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -26,7 +26,7 @@ First bundle your dependencies, then run `rake`. `rake` will default to building
 
 ```shell
 bundle
-bundle exec rake
+bin/rake
 ```
 
 When testing your application's integration with this extension you may use its factories.

--- a/lib/solidus_dev_support/templates/extension/bin/rake
+++ b/lib/solidus_dev_support/templates/extension/bin/rake
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("rake", "rake")

--- a/lib/solidus_dev_support/templates/extension/bin/setup
+++ b/lib/solidus_dev_support/templates/extension/bin/setup
@@ -5,4 +5,4 @@ set -vx
 
 gem install bundler --conservative
 bundle update
-bundle exec rake clobber
+bin/rake clobber

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Create extension' do # rubocop:disable Metrics/BlockLength
 
   def check_default_task
     cd(install_path) do
-      output = sh('bundle exec rake')
+      output = sh('bin/rake')
       expect(output).to include('Generating dummy Rails application')
       expect(output).to include('0 examples, 0 failures')
     end


### PR DESCRIPTION
## Summary

Add a binstub for `rake` to generated extension, this is in line with the binstubs provided by newly generated Rails apps.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
