### PR TITLE
Fix eval_gemfile call breaking Dependabot analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added a binstub for `rake` to the extension generator
 - Added the ability for the generator to reuse existing data for the gemspec
 
+### Fixed
+
+- Fixed Dependabot throwing an error because of `eval_gemfile` in the Gemfile
+
 ## [0.6.0] - 2020-01-20
 
 ### Added

--- a/lib/solidus_dev_support/templates/extension/Gemfile
+++ b/lib/solidus_dev_support/templates/extension/Gemfile
@@ -26,5 +26,8 @@ end
 gemspec
 
 # Use a local Gemfile to include development dependencies that might not be
-# relevant for the project or for other contributors, e.g.: `gem 'pry-debug'`.
-eval_gemfile 'Gemfile-local' if File.exist? 'Gemfile-local'
+# relevant for the project or for other contributors, e.g. pry-byebug.
+#
+# We use `send` instead of calling `eval_gemfile` to work around an issue with
+# how Dependabot parses projects: https://github.com/dependabot/dependabot-core/issues/1658.
+send(:eval_gemfile, 'Gemfile-local') if File.exist? 'Gemfile-local'


### PR DESCRIPTION
Fixes #80.

## Summary

Fixes Dependabot throwing an error because of `eval_gemfile` in the Gemfile by simply using `send(:eval_gemfile, ...)` instead.

Details about the rationale behind the fix are in the description.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
