### PR TITLE
Require with factory_bot instead of factory_bot_rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2020-02-13
+
+### Fixed
+
+- Fixed missing factory definitions when using `modify` on Solidus factories
+
 ## [1.0.0] - 2020-02-07
 
 ### Added

--- a/lib/solidus_dev_support/rspec/rails_helper.rb
+++ b/lib/solidus_dev_support/rspec/rails_helper.rb
@@ -12,7 +12,7 @@ require 'solidus_dev_support'
 
 require 'rspec/rails'
 require 'database_cleaner'
-require 'factory_bot_rails'
+require 'factory_bot'
 require 'ffaker'
 
 require 'spree/testing_support/authorization_helpers'
@@ -21,6 +21,8 @@ require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/controller_requests'
 require 'solidus_dev_support/testing_support/preferences'
+
+FactoryBot.find_definitions
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
## Summary

By requiring `factory_bot` instead of `factory_bot_rails` we should gain
some flexibility in terms of what's possible when using Solidus
factories.

The main issue with `factory_bot_rails` is that the moment that the gem
is required it also calls `FactoryBot.find_definitions` which prevents
the extension's code from using `modify` to change Solidus-defined
factories.

The right code execution order should be:

1. require factory bot
2. require Solidus factories
3. call `find_definitions`

By handling this manually we support multiple factory usage styles.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
