### PR TITLE
we don't need the sandbox folder in git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Made Git ignore `sandbox` in generated extensions
+
 ## [1.0.1] - 2020-02-17
 
 ### Fixed

--- a/lib/solidus_dev_support/templates/extension/gitignore
+++ b/lib/solidus_dev_support/templates/extension/gitignore
@@ -14,4 +14,4 @@ pkg
 *.swp
 spec/dummy
 spec/examples.txt
-sandbox
+/sandbox

--- a/lib/solidus_dev_support/templates/extension/gitignore
+++ b/lib/solidus_dev_support/templates/extension/gitignore
@@ -14,3 +14,4 @@ pkg
 *.swp
 spec/dummy
 spec/examples.txt
+sandbox


### PR DESCRIPTION
by default the generated extension keeps the sandbox in git, this commit adds the sandbox path to gitignore by default.

## Summary

<!-- Describe what you have changed in this PR. -->

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
