### PR TITLE
correct Gemfile for sandbox generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the Gemfile for sandbox, To run the sandbox correctly we need to add Solidus to the Gemfile as well (fixes #83, #89)
+
 ### Added
 
 - Made Git ignore `sandbox` in generated extensions
+- Add option to specify `SOLIDUS_BRANCH` (default to master) for sandbox generation
 
 ## [1.0.1] - 2020-02-17
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Use Ctrl-C to stop
 #### Rebuilding the sandbox app
 
 To rebuild the sandbox app just remove the `./sandbox` folder or run `bin/sandbox`.
+You can control the DB adapter and Solidus version used with the sandbox by providing
+the `DB` and `SOLIDUS_BRANCH` env variables.
+
+```bash
+DB=[postgres|mysql|sqlite] SOLIDUS_BRANCH=<BRANCH-NAME> bin/sandbox
+```
+
+By default we use sqlite3 and the master branch.
 
 ### RSpec helpers
 

--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -18,6 +18,13 @@ sqlite|'')
   ;;
 esac
 
+if [ ! -z $SOLIDUS_BRANCH ]
+then
+  BRANCH=$SOLIDUS_BRANCH
+else
+  BRANCH="master"
+fi
+
 extension_name="<%= file_name %>"
 
 # Stay away from the bundler env of the containing extension.
@@ -42,11 +49,12 @@ fi
 
 cd ./sandbox
 cat <<RUBY >> Gemfile
-
-gem '$extension_name', path: '..'
+gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
 gem 'solidus_auth_devise', '>= 2.1.0'
 gem 'rails-i18n'
 gem 'solidus_i18n'
+
+gem '$extension_name', path: '..'
 
 group :test, :development do
   platforms :mri do
@@ -69,4 +77,7 @@ unbundled bundle exec rails generate solidus:auth:install
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"
+echo "🚀 Using $RAILSDB and Solidus $BRANCH"
+echo "🚀 Use 'export DB=[postgres|mysql|sqlite]' to control the DB adapter"
+echo "🚀 Use 'export SOLIDUS_BRANCH=<BRANCH-NAME>' to control the Solidus version"
 echo "🚀 This app is intended for test purposes."


### PR DESCRIPTION
To run the sandbox correctly we need to add Solidus to the Gemfile as well. This commit adds the option to run the sandbox with a specific Solidus `BRANCH`, by default it will be using the `master` branch.

The order of the `Gemfile` also matters, make sure we have `solidus` as the first gem and the extension under development as the last entry for the sandbox.

Fixes #89 Fixes #83 

## Summary

<!-- Describe what you have changed in this PR. -->

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
