### PR TITLE
Add Zeitwerk deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Made Git ignore `sandbox` in generated extensions
 - Added support for specifying `SOLIDUS_BRANCH` in the sandbox
+- Added deprecation warning when extensions don't support Zeitwerk
 
 ### Changed
 


### PR DESCRIPTION
This PR makes the build fail when extensions are tested against a Rails version that supports Zeitwerk and the autoloader is not able to load module/classes defined in the extension. 

This simulates a failure that could happen in staging/production, when Rails `eager_load` is set to true. 

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
- [x] I have added an entry to the changelog for this change.
