### PR TITLE
Bump solidus_support to ~> 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Updated the extension template to use latest (0.5.X) solidus_support
 - Update Ruby 2.5+ as the minimum Ruby version in generated extensions
 
 ## [1.2.0]

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.4.0'
+  spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
solidus_support gem has been updated, the latest version
is 0.5. This commit updates this template to use this 0.5.X version

## Summary

<!-- Describe what you have changed in this PR. -->

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
