### PR TITLE
Bump required Ruby version to 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Update Ruby 2.5+ as the minimum Ruby version in generated extensions
+
 ## [1.2.0]
 
 ### Changed
@@ -24,7 +28,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Split `bin/rails` into `bin/r` and `bin/sandbox_rails`
 
- 
+
 ### Fixed
 
 - Fixed the sandbox Gemfile not including Solidus

--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -180,7 +180,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - spec/dummy/**/*
     - vendor/**/*

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = '<%= gemspec.homepage %>'
   spec.metadata['changelog_uri'] = '<%= gemspec.metadata["changelog_uri"] %>'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.4')
+  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Support for Ruby 2.4 has been ended, to make sure we keep up with
the supported ruby versions this commit bumps the required Ruby version
to >= 2.5.0

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

## Summary

<!-- Describe what you have changed in this PR. -->

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
