### PR TITLE
Create the dummy app from spec_helper if missing

### DIFF
--- a/lib/solidus_dev_support/templates/extension/spec/spec_helper.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/spec/spec_helper.rb.tt
@@ -6,7 +6,10 @@ ENV['RAILS_ENV'] = 'test'
 # Run Coverage report
 require 'solidus_dev_support/rspec/coverage'
 
-require File.expand_path('dummy/config/environment.rb', __dir__)
+require File.expand_path('dummy/config/environment.rb', __dir__).tap { |file|
+  # Create the dummy app if it's still missing.
+  system 'bin/rake extension:test_app' unless File.exist? file
+}
 
 # Requires factories and other useful helpers defined in spree_core.
 require 'solidus_dev_support/rspec/feature_helper'


### PR DESCRIPTION
## Summary

When running single specs via `rspec` without the dummy app already created it outputs a not very helpful error. With this it will just create the app before running the spec.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
- [ ] I have added an entry to the changelog for this change.
