### PR TITLE
Ignore development environment configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Ignored `.rvmrc`, `.ruby-version` and `.ruby-gemset` by default in extensions
+
 ### Changed
 
 - Updated the extension template to use latest (0.5.X) solidus_support

--- a/lib/solidus_dev_support/templates/extension/gitignore
+++ b/lib/solidus_dev_support/templates/extension/gitignore
@@ -15,3 +15,6 @@ pkg
 spec/dummy
 spec/examples.txt
 /sandbox
+.rvmrc
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
Fixes #70.

## Summary

Adds `.ruby-version`, `.ruby-gemset` and `.rvmrc` to the default `.gitignore` for extensions, so that people don't accidentally commit those files into Git.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
