### PR TITLE
Move RuboCop ignore statements back to the internal configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Restored `bin/rails` and renamed the context specific bins to `bin/rails-engine` and `bin/rails-sandbox`
 - Adjusted the readme structure with better formatting and grammar
+- Moved the RuboCop `AllCops/Exclude` statement back to the internal configuration 
 
 ### Deprecated
 

--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -183,6 +183,7 @@ AllCops:
   TargetRubyVersion: 2.5
   Exclude:
     - spec/dummy/**/*
+    - sandbox/**/*
     - vendor/**/*
 
 Metrics/BlockLength:

--- a/lib/solidus_dev_support/templates/extension/rubocop.yml
+++ b/lib/solidus_dev_support/templates/extension/rubocop.yml
@@ -1,7 +1,2 @@
 require:
   - solidus_dev_support/rubocop
-
-AllCops:
-  Exclude:
-    - sandbox/**/*
-    - spec/dummy/**/*


### PR DESCRIPTION
## Summary

Moves the RuboCop `AllCops/Exclude` statement back to the internal configuration. Rationale in the commit message.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
- [x] I have added an entry to the changelog for this change.
