### PR TITLE
Get Mergify to enforce the presence of a changelog label on PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,42 @@
 pull_request_rules:
-  - name: automatic merge when GitHub branch protection passes on master
+  - name: request changelog labels when a PR is missing them
     conditions:
       - base=master
+      - -label=bug
+      - -label=enhancement
+      - -label=documentation
+      - -label=security
+      - -label=removed
+      - -label=infrastructure
+    actions:
+      label:
+        add:
+          - needs changelog label
+      comment:
+        message: >
+          It looks like this PR is missing a label to determine the type of change it introduces.
+          The maintainer should add one of the following labels:
+
+          - `bug` for bugfixes.
+          - `enhancement` for new features and improvements.
+          - `documentation` for documentation changes.
+          - `security` for security patches.
+          - `removed` for feature removals.
+          - `infrastructure` for internal changes that should not go in the changelog.
+
+          Additionally, the maintainer may also want to add one of the following:
+
+          - `breaking` for breaking changes.
+          - `deprecated` for feature deprecations.
+
+          Once the correct labels have been set, simply remove the `needs changelog label` label
+          from this PR so I can merge it.
+
+  - name: merge PRs automatically
+    conditions:
+      - base=master
+      - -label="needs changelog label"
+      - -label=blocked
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Part of #99.

## Summary

This is an attempt at getting Mergify to automatically flag PRs without the correct changelog labels.

The idea is that by using the correct labels on all PRs we can get github_changelog_generator to generate a much more meaningful changelog similar to the format suggested by [Keep a Changelog](https://keepachangelog.com).

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
- [ ] I have added an entry to the changelog for this change.
