### PR TITLE
Fix formatting typo in readme

### DIFF
--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -47,7 +47,7 @@ Simply add this require statement to your spec_helper:
 require '<%= file_name %>/factories'
 ```
 
-## Running the sandbox
+### Running the sandbox
 
 To run this extension in a sandboxed Solidus application, you can run `bin/sandbox`. The path for
 the sandbox app is `./sandbox` and `bin/rails` will forward any Rails commands to


### PR DESCRIPTION
## Summary

Fixes a minor formatting typo in our readme.

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.