### PR TITLE
Remove deprecated bin/r and bin/sandbox_rails binaries

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/r
+++ b/lib/solidus_dev_support/templates/extension/bin/r
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-
-warn %{
-DEPRECATION: bin/r has been replaced by bin/rails-engine, please use that
-command instead.
-}.strip
-
-exec "#{__dir__}/rails-engine"

--- a/lib/solidus_dev_support/templates/extension/bin/sandbox_rails
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox_rails
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-
-warn %{
-DEPRECATION: bin/sandbox_rails has been replaced by bin/rails-sandbox, please
-use that command instead.
-}.strip
-
-exec "#{__dir__}/rails-engine"


### PR DESCRIPTION
## Summary

Removes the deprecated `bin/r` and `bin/sandbox_rails` binaries. This isn't a breaking change, since the binaries have already been generated in existing extensions and won't be removed unless the author does it explicitly.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
