### PR TITLE
Don't install a payment-method in the sandbox

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -72,6 +72,7 @@ unbundled bundle exec rails generate spree:install \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with-authentication=false \
+  --payment-method=none
   $@
 
 unbundled bundle exec rails generate solidus:auth:install


### PR DESCRIPTION
Fixes the CI failure for solidus@master.

## Summary

There's a new installation flag on master, but we want it to be disabled in the sandbox.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
