### PR TITLE
Let the extension name include spaces

### DIFF
--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -1,4 +1,4 @@
-# <%= class_name %>
+# <%= class_name.gsub(/(?<=[^A-Z])([A-Z])/, ' \1') %>
 
 <!-- Replace REPO_ORG and uncomment the following to show badges for CI and coverage. -->
 
@@ -6,7 +6,6 @@
 [![CircleCI](https://circleci.com/gh/REPO_ORG/<%= file_name %>.svg?style=shield)](https://circleci.com/gh/REPO_ORG/<%= file_name %>)
 [![codecov](https://codecov.io/gh/REPO_ORG/<%= file_name %>/branch/master/graph/badge.svg)](https://codecov.io/gh/REPO_ORG/<%= file_name %>)
 -->
-
 
 [Explain what your extension does.]
 


### PR DESCRIPTION
## Summary

Changes the h1 at the top of the README to include spaces, instead of using just the class name.

This is the style aldeady chosen by most extensions and the more
natural in English.


## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
