### PR TITLE
Add a changelog generator config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased](https://github.com/solidusio/solidus_dev_support/tree/HEAD)
+
+[Full Changelog](https://github.com/solidusio/solidus_dev_support/compare/v1.5.0...HEAD)
+
+**Implemented enhancements:**
+
+- Add Changelog Rake task [\#128](https://github.com/solidusio/solidus_dev_support/pull/128) ([tvdeyen](https://github.com/tvdeyen))
+- Readme fixes [\#122](https://github.com/solidusio/solidus_dev_support/pull/122) ([elia](https://github.com/elia))
+
+**Fixed bugs:**
+
+- Don't install a payment-method in the sandbox [\#131](https://github.com/solidusio/solidus_dev_support/pull/131) ([elia](https://github.com/elia))
+- Run extension generator in sandbox [\#127](https://github.com/solidusio/solidus_dev_support/pull/127) ([elia](https://github.com/elia))
+
+**Merged pull requests:**
+
+- Add the codecov badge to the readme [\#123](https://github.com/solidusio/solidus_dev_support/pull/123) ([elia](https://github.com/elia))
+
 ## [v1.5.0](https://github.com/solidusio/solidus_dev_support/tree/v1.5.0) (2020-06-13)
 
 [Full Changelog](https://github.com/solidusio/solidus_dev_support/compare/v1.4.0...v1.5.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
 
+require 'github_changelog_generator/task'
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = 'solidusio'
+  config.project = 'solidus_dev_support'
+  config.exclude_labels = %w[infrastructure]
+  config.issues = false
+  config.base = "#{__dir__}/OLD_CHANGELOG.md"
+  config.since_tag = 'v1.4.0'
+end
+
+require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -61,12 +61,24 @@ $ bin/rails server
 Use Ctrl-C to stop
 ```
 
+### Updating the changelog
+
+Before and after releases the changelog should be updated to reflect the up-to-date status of
+the project:
+
+```shell
+bin/rake changelog
+git add CHANGELOG.md
+git commit -m "Update the changelog"
+```
+
+
 ### Releasing new versions
 
 Your new extension version can be released using `gem-release` like this:
 
 ```shell
-bundle exec gem bump -v VERSION --tag --push --remote upstream && gem release
+bundle exec gem bump -v VERSION --tag --push --remote origin && gem release
 ```
 
 ## License

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -72,7 +72,6 @@ git add CHANGELOG.md
 git commit -m "Update the changelog"
 ```
 
-
 ### Releasing new versions
 
 Your new extension version can be released using `gem-release` like this:


### PR DESCRIPTION
Related #121, but the problem is solved only for the gem itself, not for generated extensions.

## Summary

Adds the `rake changelog` task for the gem.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
