### PR TITLE
Fix missing backslash in solidus install command

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -72,7 +72,7 @@ unbundled bundle exec rails generate spree:install \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with-authentication=false \
-  --payment-method=none
+  --payment-method=none \
   $@
 
 unbundled bundle exec rails generate solidus:auth:install


### PR DESCRIPTION
## Summary

This PR fixes a typo present in the solidus install command with the additional parameter added in #131.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
