### PR TITLE
Switch the JS driver to WebDriver/Selenium

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'capybara/apparition'
+
+Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :apparition).to_sym
+Capybara.default_max_wait_time = 10
+Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
+
+Capybara.register_driver :apparition do |app|
+  Capybara::Apparition::Driver.new(app, window_size: [1920, 1080])
+end
+
+require 'spree/testing_support/capybara_ext'

--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
-require 'capybara/apparition'
+# Allow to override the initial windows size
+CAPYBARA_WINDOW_SIZE = (ENV['CAPYBARA_WINDOW_SIZE'] || '1920x1080').split('x', 2).map(&:to_i)
 
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :apparition).to_sym
+Capybara.javascript_driver = (ENV['CAPYBARA_JAVASCRIPT_DRIVER'] || "solidus_chrome_headless").to_sym
 Capybara.default_max_wait_time = 10
 Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
 
-Capybara.register_driver :apparition do |app|
-  Capybara::Apparition::Driver.new(app, window_size: [1920, 1080])
+Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
+  Capybara.register_driver :selenium_chrome_headless do |app|
+    original_driver.call(app).tap do |driver|
+      driver.options[:options].args << "--window-size=#{CAPYBARA_WINDOW_SIZE.join(',')}"
+    end
+  end
 end
 
 require 'spree/testing_support/capybara_ext'

--- a/lib/solidus_dev_support/rspec/feature_helper.rb
+++ b/lib/solidus_dev_support/rspec/feature_helper.rb
@@ -10,17 +10,7 @@
 require 'solidus_dev_support/rspec/rails_helper'
 
 require 'capybara-screenshot/rspec'
-require 'capybara/apparition'
-
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :apparition).to_sym
-Capybara.default_max_wait_time = 10
-Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
-
-Capybara.register_driver :apparition do |app|
-  Capybara::Apparition::Driver.new(app, window_size: [1920, 1080])
-end
-
-require 'spree/testing_support/capybara_ext'
+require 'solidus_dev_support/rspec/capybara'
 
 def dev_support_assets_preload
   if Rails.application.respond_to?(:precompiled_assets)

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'apparition', '~> 0.4'
   spec.add_dependency 'capybara', '~> 3.29'
   spec.add_dependency 'capybara-screenshot', '~> 1.0'
   spec.add_dependency 'codecov', '~> 0.2'
@@ -45,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.36'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 3']
+  spec.add_dependency 'webdrivers', '~> 4.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
## Summary

Since apparition has an [open issue with Chrome 85](https://github.com/twalpole/apparition/issues/64) ~~we want to open up to other drivers and let individual extensions pick the one they prefer~~ we'll switch to "webdrivers" which is Rails' default.

~~Cuprite, like Apparition, is based on CDP, for fast runs and more control over the browser.
Webdrivers relies on the [WebDriver W3C standard](https://www.w3.org/TR/webdriver2/) and [Selenium](https://www.selenium.dev) with the largest cross-browser support and the default for Rails.~~

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
