### PR TITLE
Bump RuboCop to latest 0.90.0 version

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'puma', '~> 4.3'
   spec.add_dependency 'rspec_junit_formatter'
   spec.add_dependency 'rspec-rails', '~> 4.0.0.beta3'
-  spec.add_dependency 'rubocop', '~> 0.87.1'
+  spec.add_dependency 'rubocop', '~> 0.90'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.36'


### PR DESCRIPTION
## Summary

Bump Rubocop to 0.90.0

Related: https://github.com/rubocop-hq/rubocop/issues/8713
and https://github.com/solidusio-contrib/solidus_affirm_v2/commit/448b229b6b35f62e2ef8e41e944db221684d71a7


## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
