### PR TITLE
Don't forcefully close issues via stale-bot

### DIFF
--- a/lib/solidus_dev_support/templates/extension/.github/stale.yml
+++ b/lib/solidus_dev_support/templates/extension/.github/stale.yml
@@ -1,17 +1,17 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
+  recent activity. It might be closed if no further activity occurs. Thank you
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
## Summary

Stale-bot is a bit too eager in closing issues.

Maintainers are still facilitated in closing inactive issues after a
while, but it's more forgiving to some roadmap-type issues that just
track features to come in future releases.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
