### PR TITLE
Try fixing random CI errors with an updated version of ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
   # or goes EOL.
-  solidusio_extensions: solidusio/extensions@volatile
+  solidusio_extensions: solidusio/extensions@dev:elia/update-versions
 
 commands:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
   # or goes EOL.
-  solidusio_extensions: solidusio/extensions@dev:elia/update-versions
+  solidusio_extensions: solidusio/extensions@dev:2971367
 
 commands:
   setup:


### PR DESCRIPTION
## Summary

We recently had a number of random IO/Timeout errors ([like this](https://app.circleci.com/pipelines/github/solidusio/solidus_dev_support/419/workflows/e578c2ce-19c0-401d-b2a1-f815b6fa1328/jobs/1259)), trying to fix them with an updated ruby.

They look like this:

```
#!/bin/bash -eo pipefail
bundle exec rake
/usr/local/bin/ruby -I/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-core-3.9.2/lib:/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-support-3.9.3/lib /home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-core-3.9.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Create extension
rake aborted!
Interrupt: 
/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-core-3.9.2/lib/rspec/core/rake_task.rb:97:in `system'
/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-core-3.9.2/lib/rspec/core/rake_task.rb:97:in `run_task'
/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-core-3.9.2/lib/rspec/core/rake_task.rb:116:in `block (2 levels) in define'
/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rspec-core-3.9.2/lib/rspec/core/rake_task.rb:114:in `block in define'
/home/circleci/project/vendor/bundle/v2.10/ruby/2.5.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/usr/local/bundle/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'
Tasks: TOP => default => spec
(See full trace by running task with --trace)
#<Thread:0x00005590351926c8@/usr/local/lib/ruby/2.5.0/open3.rb:354 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	1: from /usr/local/lib/ruby/2.5.0/open3.rb:354:in `block (2 levels) in capture2e'
/usr/local/lib/ruby/2.5.0/open3.rb:354:in `read': stream closed in another thread (IOError)

Finished in 10 minutes 0 seconds (files took 0.24751 seconds to load)
1 example, 0 failures


Too long with no output (exceeded 10m0s): context deadline exceeded
```

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
