### PR TITLE
fix capybara driver declaration

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -8,7 +8,7 @@ Capybara.default_max_wait_time = 10
 Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
 
 Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
-  Capybara.register_driver :selenium_chrome_headless do |app|
+  Capybara.register_driver :solidus_chrome_headless do |app|
     original_driver.call(app).tap do |driver|
       driver.options[:options].args << "--window-size=#{CAPYBARA_WINDOW_SIZE.join(',')}"
     end


### PR DESCRIPTION
## Summary

You are setting to use [`solidus_chrome_headless` like default javascript driver for capyabara](https://github.com/solidusio/solidus_dev_support/blob/master/lib/solidus_dev_support/rspec/capybara.rb#L6), but this driver is never declared.

I think your intention was to declare this driver later instead just redeclare `selenium_chrome_headless`.

So, this fix that typo

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
