### PR TITLE
Fix build timeout on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ commands:
   setup:
     steps:
       - checkout
-      - run: "gem install bundler -v '>=2' --conservative"
+      - run:
+          command: "gem install bundler -v '>=2' --conservative"
+          no_output_timeout: 20m
 
 jobs:
   solidus-master:

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -21,13 +21,18 @@ RSpec.describe 'Create extension' do
     mkdir_p(tmp_path)
   end
 
+  def step(method_name)
+    puts "Step #{method_name}"
+    send method_name
+  end
+
   it 'checks the create extension process' do
-    check_solidus_cmd
-    check_create_extension
-    check_bundle_install
-    check_default_task
-    check_run_specs
-    check_sandbox
+    step :check_solidus_cmd
+    step :check_create_extension
+    step :check_bundle_install
+    step :check_default_task
+    step :check_run_specs
+    step :check_sandbox
   end
 
   private


### PR DESCRIPTION
## Summary

This PR tries to address some random failures during CI builds by taking a two sided approach.

These failures seem to derive from specs taking longer than the default CircleCI `no_output_timeout` ([10 minutes](https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit)) to output anything on `stdout`.

## Implementation

- Change the CircleCI `no_output_timeout` to a longer one
- Make the specs output something at each step

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
