### PR TITLE
Enable new RuboCop cops automatically

### DIFF
--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -1,6 +1,6 @@
 require: ["rubocop-rspec", "rubocop-rails", "rubocop-performance"]
 
-AllCops: {TargetRubyVersion: 2.5, Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"]}
+AllCops: {TargetRubyVersion: 2.5, Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"], NewCops: enable}
 
 Layout/ArgumentAlignment: {EnforcedStyle: with_fixed_indentation}
 Layout/DotPosition: {Enabled: false, StyleGuide: "https://relaxed.ruby.style/#layoutdotposition"}


### PR DESCRIPTION
Fixes N/A.

## Summary

Enables new RuboCop cops automatically, so that we don't have to enable each cop individually.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
