### PR TITLE
Fix gem_version not being found during extension generation

### DIFF
--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -3,6 +3,8 @@
 require 'thor'
 require 'pathname'
 
+require 'solidus_dev_support/version'
+
 module SolidusDevSupport
   class Extension < Thor
     include Thor::Actions


### PR DESCRIPTION
Fixes N/A.

## Summary

Fixes an issue that was causing this error during extension generation:
```
undefined method `gem_version' for SolidusDevSupport:Module (NoMethodError)
```
I'm not sure why the tests are passing, but I suspect it's because the version file is loaded externally somehow.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
