### PR TITLE
Fix `NewCops: Enable` option for RuboCop

### DIFF
--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -1,6 +1,6 @@
 require: ["rubocop-rspec", "rubocop-rails", "rubocop-performance"]
 
-AllCops: {TargetRubyVersion: 2.5, Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"], NewCops: enable}
+AllCops: {TargetRubyVersion: 2.5, Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"]}
 
 Layout/ArgumentAlignment: {EnforcedStyle: with_fixed_indentation}
 Layout/DotPosition: {Enabled: false, StyleGuide: "https://relaxed.ruby.style/#layoutdotposition"}

--- a/lib/solidus_dev_support/templates/extension/rubocop.yml
+++ b/lib/solidus_dev_support/templates/extension/rubocop.yml
@@ -1,2 +1,5 @@
 require:
   - solidus_dev_support/rubocop
+
+AllCops:
+  NewCops: Enable


### PR DESCRIPTION
Fixes #146.

## Summary

Fixes the `NewCops: Enable` configuration option, which is not working when it's included in solidus_dev_support's built-in `.rubocop.yml`. Instead, it needs to be included in the generated `.rubocop.yml` directly.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
