### PR TITLE
Add extension configuration boilerplate

### DIFF
--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
@@ -3,5 +3,18 @@
 require 'solidus_core'
 require 'solidus_support'
 
+require '<%=file_name%>/configuration'
 require '<%=file_name%>/version'
 require '<%=file_name%>/engine'
+
+module <%= class_name %>
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
+  end
+end

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%/configuration.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%/configuration.rb.tt
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module <%= class_name %>
+  class Configuration
+    # TODO: Remember to change this with your extension's actual preferences!
+    # attr_accessor :sample_preference
+  end
+end

--- a/lib/solidus_dev_support/templates/extension/lib/generators/%file_name%/install/install_generator.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/generators/%file_name%/install/install_generator.rb.tt
@@ -4,6 +4,11 @@ module <%= class_name %>
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
+      source_root File.expand_path('templates', __dir__)
+
+      def copy_initializer
+        template 'initializer.rb', 'config/initializers/<%= file_name %>.rb'
+      end
 
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/<%= file_name %>\n"

--- a/lib/solidus_dev_support/templates/extension/lib/generators/%file_name%/install/templates/initializer.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/generators/%file_name%/install/templates/initializer.rb.tt
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+<%= class_name %>.configure do |config|
+  # TODO: Remember to change this with the actual preferences you have implemented!
+  # config.sample_preference = 'sample_value'
+end


### PR DESCRIPTION
Fixes #145.

## Summary

Generates a simple, standard configuration API for new extensions.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
