### PR TITLE
Add standard github_changelog_generator configuration

### DIFF
--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -40,6 +40,7 @@ module SolidusDevSupport
       template 'rspec', "#{path}/.rspec"
       template 'spec/spec_helper.rb.tt', "#{path}/spec/spec_helper.rb"
       template 'rubocop.yml', "#{path}/.rubocop.yml"
+      template 'github_changelog_generator', "#{path}/.github_changelog_generator"
     end
 
     no_tasks do

--- a/lib/solidus_dev_support/templates/extension/github_changelog_generator
+++ b/lib/solidus_dev_support/templates/extension/github_changelog_generator
@@ -1,0 +1,2 @@
+issues=false
+exclude-labels=infrastructure


### PR DESCRIPTION
Fixes #121.

## Summary

Adds a standard configuration for github_changelog_generator. As long as the standard labels are used on all PRs and releases are properly used, this guarantees a nice, consistent changelog for all extensions.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
