### PR TITLE
require webdrivers

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'webdrivers/chromedriver'
+
 # Allow to override the initial windows size
 CAPYBARA_WINDOW_SIZE = (ENV['CAPYBARA_WINDOW_SIZE'] || '1920x1080').split('x', 2).map(&:to_i)
 


### PR DESCRIPTION
## Summary

We have `webdrivers` gem like dependency, but in order to use we should require the gem https://github.com/titusfortner/webdrivers#usage

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
