### PR TITLE
Don't let mergify mark a PR as red because it's missing a review

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,6 +34,8 @@ pull_request_rules:
       - base=master
       - -label="needs changelog label"
       - -label=blocked
+      - "#approved-reviews-by>=1"
+      - -draft
     actions:
       merge:
         method: merge

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,6 @@ Style/RedundantRegexpEscape:
 Style/SlicingWithRange:
   Enabled: true
 
-
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:
@@ -44,6 +43,7 @@ AllCops:
     - "vendor/**/*"
     # Generated binstubs
     - bin/rake
+  NewCops: enable
 
 Style/FrozenStringLiteralComment:
   Exclude:

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -69,7 +69,7 @@ module SolidusDevSupport
           gem.email = git('config user.email', 'TODO: Write your email address')
           gem.homepage = default_homepage
           gem.license = 'BSD-3-Clause'
-          gem.metadata['changelog_uri'] = default_homepage + '/releases'
+          gem.metadata['changelog_uri'] = "#{default_homepage}/releases"
           gem.summary = 'TODO: Write a short summary, because RubyGems requires one.'
         end
       end

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe 'Create extension' do
   let(:gemspec_name) { "solidus_#{extension_name}.gemspec" }
   let(:tmp_path) { Pathname.new(gem_root).join('tmp') }
   let(:install_path) { tmp_path.join("solidus_#{extension_name}") }
-
-  class CommandFailed < StandardError; end
+  let(:command_failed_error) { Class.new(StandardError) }
 
   before do
     rm_rf(install_path)
@@ -83,7 +82,7 @@ RSpec.describe 'Create extension' do
       open('Gemfile', 'a') { |f| f.puts "gem 'solidus_dev_support', path: '../../..'" }
     end
 
-    expect { bundle_install }.to raise_error(CommandFailed, /invalid gemspec/)
+    expect { bundle_install }.to raise_error(command_failed_error, /invalid gemspec/)
 
     # Update gemspec with the required fields
     gemspec_path = install_path.join(gemspec_name)
@@ -144,7 +143,7 @@ RSpec.describe 'Create extension' do
         warn "$ #{command}"
         warn output.to_s
       end
-      raise(CommandFailed, "command failed: #{command}\n#{output}")
+      raise(command_failed_error, "command failed: #{command}\n#{output}")
     end
   end
 


### PR DESCRIPTION
## Summary

GitHub status checks should and are tracked separately from reviews.

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
