### PR TITLE
Add a command to display gem's version

### DIFF
--- a/lib/solidus_dev_support/solidus_command.rb
+++ b/lib/solidus_dev_support/solidus_command.rb
@@ -13,6 +13,12 @@ module SolidusDevSupport
     desc 'e', 'Manage solidus extensions (shortcut for "extension")'
     subcommand 'e', Extension
 
+    desc 'version', 'Displays solidus_dev_support version'
+    def version
+      puts "Solidus Dev Support version #{SolidusDevSupport::VERSION}"
+    end
+    map ['-v', '--version'] => :version
+
     def self.exit_on_failure?
       true
     end

--- a/lib/solidus_dev_support/solidus_command.rb
+++ b/lib/solidus_dev_support/solidus_command.rb
@@ -2,6 +2,7 @@
 
 require 'thor'
 require 'solidus_dev_support/extension'
+require 'spree/core/version'
 
 module SolidusDevSupport
   class SolidusCommand < Thor
@@ -15,6 +16,7 @@ module SolidusDevSupport
 
     desc 'version', 'Displays solidus_dev_support version'
     def version
+      puts "Solidus version #{Spree.solidus_gem_version}"
       puts "Solidus Dev Support version #{SolidusDevSupport::VERSION}"
     end
     map ['-v', '--version'] => :version

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'open3'
 require 'spec_helper'
+require 'spree/core/version'
 
 RSpec.describe 'Create extension' do
   include FileUtils
@@ -49,11 +50,13 @@ RSpec.describe 'Create extension' do
   def check_gem_version
     gem_version_commands = ['version', '--version', '-v']
     gem_version = SolidusDevSupport::VERSION
+    solidus_version = Spree.solidus_gem_version
 
     cd(tmp_path) do
       gem_version_commands.each do |gem_version_cmd|
         output = `#{solidus_cmd} #{gem_version_cmd}`
         expect($?).to be_success
+        expect(output).to include("Solidus version #{solidus_version}")
         expect(output).to include("Solidus Dev Support version #{gem_version}")
       end
     end

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Create extension' do
 
   it 'checks the create extension process' do
     step :check_solidus_cmd
+    step :check_gem_version
     step :check_create_extension
     step :check_bundle_install
     step :check_default_task
@@ -42,6 +43,19 @@ RSpec.describe 'Create extension' do
       output = `#{solidus_cmd} -h`
       expect($?).to be_success
       expect(output).to include('Commands:')
+    end
+  end
+
+  def check_gem_version
+    gem_version_commands = ['version', '--version', '-v']
+    gem_version = SolidusDevSupport::VERSION
+
+    cd(tmp_path) do
+      gem_version_commands.each do |gem_version_cmd|
+        output = `#{solidus_cmd} #{gem_version_cmd}`
+        expect($?).to be_success
+        expect(output).to include("Solidus Dev Support version #{gem_version}")
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #61.

## Summary

This adds a command `version` to display the current gem version. It also responds to `-v` and `--version`.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
