### PR TITLE
Release SOP fixes

### DIFF
--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -76,9 +76,11 @@ module SolidusDevSupport
     def install_changelog_task
       require 'github_changelog_generator/task'
 
-      user, project = gemspec.homepage.split("/")[3..5]
+      source_code_uri = URI.parse(gemspec.metadata['source_code_uri'] || gemspec.homepage)
+      user, project = source_code_uri.path.split("/", 3)[1..2]
+
       GitHubChangelogGenerator::RakeTask.new(:changelog) do |config|
-        config.user = user || 'solidus-contrib'
+        config.user = user || 'solidusio-contrib'
         config.project = project || gemspec.name
         config.future_release = "v#{gemspec.version}"
       end

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -86,8 +86,10 @@ Your new extension version can be released using `gem-release` like this:
 ```shell
 bundle exec gem bump -v 1.6.0
 bin/rake changelog
-git commit -a --amend
-git push
+git add CHANGELOG.md
+git commit --amend --no-edit
+gem tag
+git push --tags
 bundle exec gem release
 ```
 

--- a/lib/solidus_dev_support/templates/extension/gem_release.yml.tt
+++ b/lib/solidus_dev_support/templates/extension/gem_release.yml.tt
@@ -2,4 +2,4 @@ bump:
   recurse: false
   file: 'lib/<%=file_name%>/version.rb'
   message: Bump <%=class_name%> to %{version}
-  tag: true
+  tag: false


### PR DESCRIPTION
## Summary

- we had problems when the homepage was including `#readme` in the URI
- we were tagging the wrong commit (the one without the changelog) when releasing

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
