### PR TITLE
Upgrade to RuboCop 1.0

### DIFF
--- a/lib/solidus_dev_support/templates/extension/rubocop.yml
+++ b/lib/solidus_dev_support/templates/extension/rubocop.yml
@@ -2,4 +2,4 @@ require:
   - solidus_dev_support/rubocop
 
 AllCops:
-  NewCops: Enable
+  NewCops: disable

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'puma', '~> 4.3'
   spec.add_dependency 'rspec_junit_formatter'
   spec.add_dependency 'rspec-rails', '~> 4.0.0.beta3'
-  spec.add_dependency 'rubocop', '~> 0.90'
+  spec.add_dependency 'rubocop', '~> 1.0'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.36'


### PR DESCRIPTION
## Summary

Upgrades us to RuboCop 1.0 and disables any new cops. This is a better policy than enabling them automatically, which can easily cause issue in upgrades between minor RuboCop versions.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
