### PR TITLE
Refer to Solidus wiki page for gem release info

### DIFF
--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -81,15 +81,7 @@ git commit -m "Update the changelog"
 
 ### Releasing new versions
 
-Your new extension version can be released using `gem-release` like this:
-
-```shell
-bundle exec gem bump -v 1.6.0
-bin/rake changelog
-git commit -a --amend
-git push
-bundle exec gem release
-```
+Please refer to the dedicated [page](https://github.com/solidusio/solidus/wiki/How-to-release-extensions) on Solidus wiki.
 
 ## License
 


### PR DESCRIPTION
We now have a dedicated page on Solidus wiki on how to release extensions. 

By keeping the release documentation centralized in a single place will make updating it much easier, and will avoid
having no-more-relevant information possibily scattered in many extension READMEs.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
