### PR TITLE
Configuration Cleanup

### DIFF
--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
@@ -6,15 +6,3 @@ require 'solidus_support'
 require '<%=file_name%>/configuration'
 require '<%=file_name%>/version'
 require '<%=file_name%>/engine'
-
-module <%= class_name %>
-  class << self
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    def configure
-      yield configuration
-    end
-  end
-end

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%/configuration.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%/configuration.rb.tt
@@ -2,7 +2,18 @@
 
 module <%= class_name %>
   class Configuration
-    # TODO: Remember to change this with your extension's actual preferences!
-    # attr_accessor :sample_preference
+    # Define here the settings for this extensions, e.g.:
+    #
+    # attr_accessor :my_setting
+  end
+
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
   end
 end

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%/configuration.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%/configuration.rb.tt
@@ -12,6 +12,8 @@ module <%= class_name %>
       @configuration ||= Configuration.new
     end
 
+    alias config configuration
+
     def configure
       yield configuration
     end


### PR DESCRIPTION
## Summary

Optimize for dev-support updates cleaning up the main file and collecting anything related to config within configuration.rb.
Also aliases `configuration` as `config` which is more widely used in the rails world.

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
