### PR TITLE
Improve the URL generation for the gemspec and Readme (defaulting to the solidusio-contrib organization), consistently use a file-based Changelog

### DIFF
--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -71,10 +71,11 @@ module SolidusDevSupport
       def default_gemspec
         @default_gemspec ||= Gem::Specification.new(file_name, '0.0.1') do |gem|
           gem.author = git('config user.name', 'TODO: Write your name')
-          gem.description = 'TODO: Write a longer description or delete this line.'
           gem.email = git('config user.email', 'TODO: Write your email address')
-          gem.license = 'BSD-3-Clause'
+
           gem.summary = 'TODO: Write a short summary, because RubyGems requires one.'
+          gem.description = 'TODO: Write a longer description or delete this line.'
+          gem.license = 'BSD-3-Clause'
 
           gem.metadata['homepage_uri'] = gem.homepage = "https://github.com/#{repo}#readme"
           gem.metadata['changelog_uri'] = "https://github.com/#{repo}/blob/master/CHANGELOG.md"

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -55,6 +55,8 @@ module SolidusDevSupport
         @root = File.dirname(path)
         @path = File.join(root, file_name)
 
+        @repo = existing_repo || default_repo
+
         @gemspec = existing_gemspec || default_gemspec
       end
 
@@ -97,11 +99,19 @@ module SolidusDevSupport
         )
       end
 
+      def default_repo
+        "solidusio-contrib/#{file_name}"
+      end
+
+      def existing_repo
+        git('remote get-url origin')&.sub(%r{^.*github\.com.([^/]+)/([^/.]+).*$}, '\1/\2')
+      end
+
       def github_user
         @github_user ||= git('config github.user', '[USERNAME]')
       end
 
-      def git(command, default)
+      def git(command, default = nil)
         result = `git #{command} 2> /dev/null`.strip
         result.empty? ? default : result
       end
@@ -112,7 +122,7 @@ module SolidusDevSupport
         path.chmod(executable)
       end
 
-      attr_reader :root, :path, :file_name, :class_name, :gemspec
+      attr_reader :root, :path, :file_name, :class_name, :gemspec, :repo
     end
 
     def self.source_root

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -50,10 +50,10 @@ module SolidusDevSupport
         @file_name = Thor::Util.snake_case(File.basename(path))
         @file_name = PREFIX + @file_name unless @file_name.start_with?(PREFIX)
 
-        @class_name = Thor::Util.camel_case @file_name
+        @class_name = Thor::Util.camel_case file_name
 
         @root = File.dirname(path)
-        @path = File.join(@root, @file_name)
+        @path = File.join(root, file_name)
 
         @gemspec = existing_gemspec || default_gemspec
       end
@@ -63,7 +63,7 @@ module SolidusDevSupport
       end
 
       def default_gemspec
-        @default_gemspec ||= Gem::Specification.new(@file_name, '0.0.1') do |gem|
+        @default_gemspec ||= Gem::Specification.new(file_name, '0.0.1') do |gem|
           gem.author = git('config user.name', 'TODO: Write your name')
           gem.description = 'TODO: Write a longer description or delete this line.'
           gem.email = git('config user.email', 'TODO: Write your email address')

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -28,6 +28,7 @@ module SolidusDevSupport
         make_executable bin
       end
 
+      template 'CHANGELOG.md', "#{path}/CHANGELOG.md"
       template 'extension.gemspec', "#{path}/#{file_name}.gemspec"
       template 'Gemfile', "#{path}/Gemfile"
       template 'gitignore', "#{path}/.gitignore"

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -60,6 +60,10 @@ module SolidusDevSupport
         @gemspec = existing_gemspec || default_gemspec
       end
 
+      attr_reader :root, :path, :file_name, :class_name, :gemspec, :repo
+
+      private
+
       def gemspec_path
         @gemspec_path ||= File.join(path, "#{file_name}.gemspec")
       end
@@ -69,10 +73,12 @@ module SolidusDevSupport
           gem.author = git('config user.name', 'TODO: Write your name')
           gem.description = 'TODO: Write a longer description or delete this line.'
           gem.email = git('config user.email', 'TODO: Write your email address')
-          gem.homepage = default_homepage
           gem.license = 'BSD-3-Clause'
-          gem.metadata['changelog_uri'] = "#{default_homepage}/releases"
           gem.summary = 'TODO: Write a short summary, because RubyGems requires one.'
+
+          gem.metadata['homepage_uri'] = gem.homepage = "https://github.com/#{repo}#readme"
+          gem.metadata['changelog_uri'] = "https://github.com/#{repo}/blob/master/CHANGELOG.md"
+          gem.metadata['source_code_uri'] = "https://github.com/#{repo}"
         end
       end
 
@@ -82,21 +88,15 @@ module SolidusDevSupport
         @existing_gemspec ||= Gem::Specification.load(gemspec_path).tap do |spec|
           spec.author ||= default_gemspec.author
           spec.email ||= default_gemspec.email
-          spec.homepage ||= default_gemspec.homepage
-          spec.license ||= default_gemspec.license
-          spec.metadata['changelog_uri'] ||= default_gemspec.metadata[:changelog_uri]
-          spec.summary ||= default_gemspec.summary
-        end
-      end
 
-      def default_homepage
-        @default_homepage ||= git(
-          'remote get-url origin',
-          "git@github.com:#{github_user}/#{file_name}.git"
-        ).sub(
-          %r{^.*github\.com.([^/]+)/([^/.]+).*$},
-          'https://github.com/\1/\2'
-        )
+          spec.summary ||= default_gemspec.summary
+          spec.license ||= default_gemspec.license
+
+          spec.homepage ||= default_gemspec.homepage
+          spec.metadata['source_code_uri'] ||= default_gemspec.metadata['source_code_uri']
+          spec.metadata['changelog_uri'] ||= default_gemspec.metadata['changelog_uri']
+          spec.metadata['source_code_uri'] ||= default_gemspec.metadata['source_code_uri']
+        end
       end
 
       def default_repo
@@ -105,10 +105,6 @@ module SolidusDevSupport
 
       def existing_repo
         git('remote get-url origin')&.sub(%r{^.*github\.com.([^/]+)/([^/.]+).*$}, '\1/\2')
-      end
-
-      def github_user
-        @github_user ||= git('config github.user', '[USERNAME]')
       end
 
       def git(command, default = nil)
@@ -121,8 +117,6 @@ module SolidusDevSupport
         executable = (path.stat.mode | 0o111)
         path.chmod(executable)
       end
-
-      attr_reader :root, :path, :file_name, :class_name, :gemspec, :repo
     end
 
     def self.source_root

--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -76,11 +76,13 @@ module SolidusDevSupport
     def install_changelog_task
       require 'github_changelog_generator/task'
 
-      user, project = gemspec.homepage.split("/")[3..5]
       GitHubChangelogGenerator::RakeTask.new(:changelog) do |config|
-        config.user = user || 'solidus-contrib'
-        config.project = project || gemspec.name
-        config.future_release = "v#{gemspec.version}"
+        require 'octokit'
+        repo = Octokit::Repository.from_url(gemspec.metadata['source_code_uri'] || gemspec.homepage)
+
+        config.user = repo.owner
+        config.project = repo.name
+        config.future_release = "v#{ENV['UNRELEASED_VERSION'] || gemspec.version}"
       end
     end
   end

--- a/lib/solidus_dev_support/templates/extension/CHANGELOG.md
+++ b/lib/solidus_dev_support/templates/extension/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/REPO_ORG/<%= file_name %>/branch/master/graph/badge.svg)](https://codecov.io/gh/REPO_ORG/<%= file_name %>)
 -->
 
-[Explain what your extension does.]
+<!-- Explain what your extension does. -->
 
 ## Installation
 
@@ -25,7 +25,7 @@ bin/rails generate <%= file_name %>:install
 
 ## Usage
 
-[Explain how to use your extension once it's been installed.]
+<!-- Explain how to use your extension once it's been installed. -->
 
 ## Development
 

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -1,11 +1,7 @@
 # <%= class_name.gsub(/(?<=[^A-Z])([A-Z])/, ' \1') %>
 
-<!-- Replace REPO_ORG and uncomment the following to show badges for CI and coverage. -->
-
-<!--
-[![CircleCI](https://circleci.com/gh/REPO_ORG/<%= file_name %>.svg?style=shield)](https://circleci.com/gh/REPO_ORG/<%= file_name %>)
-[![codecov](https://codecov.io/gh/REPO_ORG/<%= file_name %>/branch/master/graph/badge.svg)](https://codecov.io/gh/REPO_ORG/<%= file_name %>)
--->
+[![CircleCI](https://circleci.com/gh/<%= repo %>.svg?style=shield)](https://circleci.com/gh/<%= repo %>)
+[![codecov](https://codecov.io/gh/<%= repo %>/branch/master/graph/badge.svg)](https://codecov.io/gh/<%= repo %>)
 
 <!-- Explain what your extension does. -->
 

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license = '<%= gemspec.license %>'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = '<%= gemspec.homepage %>'
+  spec.metadata['source_code_uri'] = '<%= gemspec.metadata["source_code_uri"] %>'
   spec.metadata['changelog_uri'] = '<%= gemspec.metadata["changelog_uri"] %>'
 
   spec.required_ruby_version = Gem::Requirement.new('~> 2.5')

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.email = '<%= gemspec.email %>'
 
   spec.summary = '<%= gemspec.summary %>'
-  spec.description = '<%= gemspec.description %>'
-  spec.homepage = '<%= gemspec.homepage %>'
+  <% if gemspec.description %>spec.description = '<%= gemspec.description %>'
+  <% end %>spec.homepage = '<%= gemspec.homepage %>'
   spec.license = '<%= gemspec.license %>'
 
   spec.metadata['homepage_uri'] = spec.homepage

--- a/spec/lib/extension_spec.rb
+++ b/spec/lib/extension_spec.rb
@@ -1,33 +1,69 @@
 require 'solidus_dev_support/extension'
 
 RSpec.describe SolidusDevSupport::Extension do
-  describe '#default_homepage' do
-    before do
-      expect(subject).to receive(:git).with('remote get-url origin', any_args).and_return(remote)
-      expect(subject).to receive(:github_user).and_return('[USERNAME]')
-      expect(subject).to receive(:file_name).and_return('solidus_foo_bar')
-    end
+  describe '#path=' do
+    specify 'with an existing extension' do
+      allow(subject).to receive(:git).with('remote get-url origin', any_args).and_return('git@github.com:some_user/solidus_my_ext.git')
+      allow(subject).to receive(:git).with('config user.name', any_args).and_return('John Doe')
+      allow(subject).to receive(:git).with('config user.email', any_args).and_return('john.doe@example.com')
 
-    context 'with a git ssh-style remote' do
-      let(:remote) { 'git@github.com:solidusio-contrib/solidus_extension_dev_tools.git' }
+      allow(File).to receive(:exist?).with('/foo/bar/solidus_my_ext/solidus_my_ext.gemspec').and_return(true)
+      allow(Gem::Specification).to receive(:load).with('/foo/bar/solidus_my_ext/solidus_my_ext.gemspec').and_return(
+        Gem::Specification.new('solidus_my_ext', '0.1.1') do |gem|
+          gem.author = "Jane Doe"
+          gem.email = "jane.doe@example.com"
 
-      it 'generates a github home page value' do
-        expect(subject.default_homepage).to eq('https://github.com/solidusio-contrib/solidus_extension_dev_tools')
+          gem.summary = 'This extension is awesome!'
+          gem.license = 'MIT'
+
+          gem.homepage = "some_user.github.io/solidus_my_ext"
+          gem.metadata['changelog_uri'] = "https://github.com/some_user/solidus_my_ext/releases"
+          gem.metadata['source_code_uri'] = "https://github.com/some_user/solidus_my_ext"
+        end
+      )
+
+      subject.path = '/foo/bar/solidus_my_ext'
+
+      aggregate_failures do
+        expect(subject.file_name).to eq("solidus_my_ext")
+        expect(subject.class_name).to eq("SolidusMyExt")
+        expect(subject.root).to eq("/foo/bar")
+        expect(subject.path).to eq("/foo/bar/solidus_my_ext")
+        expect(subject.repo).to eq("some_user/solidus_my_ext")
+        expect(subject.gemspec.author).to eq('Jane Doe')
+        expect(subject.gemspec.email).to eq('jane.doe@example.com')
+        expect(subject.gemspec.summary).to eq('This extension is awesome!')
+        expect(subject.gemspec.license).to eq('MIT')
+        expect(subject.gemspec.homepage).to eq("some_user.github.io/solidus_my_ext")
+        expect(subject.gemspec.metadata['changelog_uri']).to eq("https://github.com/some_user/solidus_my_ext/releases")
+        expect(subject.gemspec.metadata['source_code_uri']).to eq("https://github.com/some_user/solidus_my_ext")
       end
     end
 
-    context 'with a git https remote' do
-      let(:remote) { 'https://github.com/solidusio-contrib/solidus_extension_dev_tools.git' }
+    specify 'when creating a new extension' do
+      allow(subject).to receive(:git).with('remote get-url origin', any_args) { |_, default| default }
+      allow(subject).to receive(:git).with('config user.name', any_args).and_return('John Doe')
+      allow(subject).to receive(:git).with('config user.email', any_args).and_return('john.doe@example.com')
 
-      it 'generates a github home page value' do
-        expect(subject.default_homepage).to eq('https://github.com/solidusio-contrib/solidus_extension_dev_tools')
+      allow(Dir).to receive(:pwd).and_return('/foo/bar')
+
+      subject.path = '/foo/bar/solidus_my_ext'
+
+      aggregate_failures do
+        expect(subject.file_name).to eq("solidus_my_ext")
+        expect(subject.class_name).to eq("SolidusMyExt")
+        expect(subject.root).to eq("/foo/bar")
+        expect(subject.path).to eq("/foo/bar/solidus_my_ext")
+        expect(subject.repo).to eq("solidusio-contrib/solidus_my_ext")
+        expect(subject.gemspec.author).to eq('John Doe')
+        expect(subject.gemspec.email).to eq('john.doe@example.com')
+        expect(subject.gemspec.summary).to eq('TODO: Write a short summary, because RubyGems requires one.')
+        expect(subject.gemspec.description).to eq('TODO: Write a longer description or delete this line.')
+        expect(subject.gemspec.license).to eq('BSD-3-Clause')
+        expect(subject.gemspec.homepage).to eq("https://github.com/solidusio-contrib/solidus_my_ext#readme")
+        expect(subject.gemspec.metadata['changelog_uri']).to eq("https://github.com/solidusio-contrib/solidus_my_ext/blob/master/CHANGELOG.md")
+        expect(subject.gemspec.metadata['source_code_uri']).to eq("https://github.com/solidusio-contrib/solidus_my_ext")
       end
-    end
-  end
-
-  describe '#default_gemspec' do
-    it 'has a changelog_uri' do
-      expect(subject.default_gemspec.metadata['changelog_uri']).to end_with('/releases')
     end
   end
 end


### PR DESCRIPTION
## Summary

- changelog generation was broken if the homepage wasn't the bare repo url (e.g. had a `#readme` anchor)
- now all metadata is correctly generated from a repo name
- a few improvements to the readme
- a changelog file is generated upon creation

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
