### PR TITLE
use rubocop-rspec 2.x

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '~> 1.0'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'
-  spec.add_dependency 'rubocop-rspec', '~> 1.36'
+  spec.add_dependency 'rubocop-rspec', '~> 2.0'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 3']
   spec.add_dependency 'webdrivers', '~> 4.4'
 


### PR DESCRIPTION
## Summary

Running `rubocop` with current `solidus_dev_support` version throws an error.

The problem is that [rubocop-rspec 1.x is not compatible with rubocop 1.0](https://github.com/rubocop-hq/rubocop-rspec/issues/1066#issuecomment-718174465)

Updating `rubocop-rspec` to 2.0. solve the problem

## Checklist

- [ ] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
