### PR TITLE
Do not raise if source_code_uri is missing in the gemspec

### DIFF
--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -83,6 +83,16 @@ module SolidusDevSupport
         config.user = repo.owner
         config.project = repo.name
         config.future_release = "v#{ENV['UNRELEASED_VERSION'] || gemspec.version}"
+
+      rescue Octokit::InvalidRepository
+        warn <<~WARN
+          It won't be possible to automatically generate the CHANGELOG for this extension because the
+          gemspec is missing the `source_code_uri` metadata. Please add this line to the gemspec to
+          enable automatic CHANGELOG generation:
+
+              s.metadata["source_code_uri"] = 'https://github.com/org/repo'
+
+        WARN
       end
     end
   end


### PR DESCRIPTION
## Summary

<!-- Describe what you have changed in this PR. -->

That metadata is useful to automatically generate the CHANGELOG based on GitHub activity, using Oktokit and github_changelog_generator.

But a lot of extensions do not have that metadata set. We can be more kind by not making specs ran with rake (which are unrelated) fail when that information is missing.

This is the output when that metadata is missing after this PR will be merged:

```sh
$ bundle exec rake
It won't be possible to automatically generate the CHANGELOG for this extension because the
gemspec is missing the `source_code_uri` metadata. Please add this line to the gemspec to
enable automatic CHANGELOG generation:

    s.metadata["source_code_uri"] = 'https://github.com/org/repo'

```

Refs:

- https://github.com/solidusio-contrib/solidus_globalize/issues/121#issuecomment-760102482
- https://github.com/solidusio-contrib/solidus_redirector/pull/7

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
