### PR TITLE
Remove double require of core factories from rails_helper

### DIFF
--- a/lib/solidus_dev_support/rspec/rails_helper.rb
+++ b/lib/solidus_dev_support/rspec/rails_helper.rb
@@ -16,7 +16,6 @@ require 'factory_bot'
 require 'ffaker'
 
 require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/controller_requests'


### PR DESCRIPTION
## Summary

It shouldn't create big issues but that file is currently required twice. It is also part of `solidus_dev_support/testing_support/factories` which is required a couple of lines below.


## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
