### PR TITLE
Improve engine's requires to remove double inclusions

### DIFF
--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%.rb.tt
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'solidus_core'
-require 'solidus_support'
-
 require '<%=file_name%>/configuration'
 require '<%=file_name%>/version'
 require '<%=file_name%>/engine'

--- a/lib/solidus_dev_support/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/lib/%file_name%/engine.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/core'
-require '<%= file_name %>'
+require 'solidus_core'
+require 'solidus_support'
 
 module <%= class_name %>
   class Engine < Rails::Engine


### PR DESCRIPTION
## Summary

Into the engine.rb template, with 3db5d7b, we started including the main gem's .rb file in order to have solidus_support available when the engine was loaded stand-alone (for example when running `bin/r migration add ...` in an extension). See the PR that the above commit belongs to for more details.

But that main .rb file was requiring the engine itself so we can refactor requires in order to have a clean state.

We also changed the `spree/core` require in `solidus_core` since they are equivalent (`solidus_core` only requires `spree/core`), see https://github.com/solidusio/solidus/blob/ed88ebc464d1373dc28f4d69cc9fd12c943ddfbe/core/lib/solidus_core.rb .

We've tested this change with solidus_stripe both running specs and executing `bin/r generate migration AddStoreIdToProducts`.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] ~I have added relevant automated tests for this change.~
