### PR TITLE
Rename spree:install to solidus:install in the sandbox template

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -67,7 +67,7 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate spree:install \
+unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \


### PR DESCRIPTION
`spree:install` task have been renamed to `solidus:install` (reference https://github.com/solidusio/solidus/pull/3538)

We had an issue while creating new sandboxes with *solidus_subscriptions* extension (ref: https://github.com/solidusio-contrib/solidus_subscriptions/issues/196).

## Tests
- I uninstalled previous versions of *solidus_dev_support* from my system
- I installed *solidus_dev_support* from this PR branch
- I executed `solidus extension .` in *solidus_dev_support* project to update **bin/sandbox**
- I recreated the sandbox using `bin/rails-sandbox`

Result:
- The _"Could not find generator 'spree:install'."_ error line is gone

## Checklist

- [X] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
