### PR TITLE
Fix loading factories in extensions after the last changes in Solidus

### DIFF
--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -1,26 +1,50 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories'
-require 'factory_bot'
+begin
+  require 'spree/testing_support/factory_bot'
+rescue LoadError
+  require 'factory_bot'
+  require 'spree/testing_support/factories'
+end
 
 module SolidusDevSupport
   module TestingSupport
     module Factories
       def self.load_for(*engines)
         paths = engines.flat_map do |engine|
-          engine.root.glob('lib/**/factories.rb')
+          factories_file_or_folder = engine.root.glob('lib/*/testing_support/factories{,.rb}')
+
+          if factories_file_or_folder.size == 2 && using_factory_bot_definition_file_paths?
+            folder, file = factories_file_or_folder.partition(&:directory?).map(&:first).map { |path| path.to_s.gsub(engine.root.to_s, '') }
+            ActiveSupport::Deprecation.warn <<-WARN.squish, caller(4)
+              SolidusDevSupport::TestingSupport::Factories.load_for() is automatically loading
+              all factories present into #{folder}. You should now safely remove #{file} if it
+              is only used to load ./factories content.
+            WARN
+
+            engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
+          else
+            factories_file_or_folder
+          end.map { |path| path.sub(/.rb\z/, '').to_s }
         end
 
-        if Spree::TestingSupport.respond_to? :load_all_factories
-          FactoryBot.definition_file_paths.concat(
-            paths.map { |path| path.sub(/.rb\z/, '').to_s }
-          )
+        if using_factory_bot_definition_file_paths?
+          FactoryBot.definition_file_paths = [
+            Spree::TestingSupport::FactoryBot.definition_file_paths,
+            paths,
+          ].flatten
+
           FactoryBot.reload
         else
           FactoryBot.find_definitions
 
           paths.each { |path| require path }
         end
+      end
+
+      def self.using_factory_bot_definition_file_paths?
+        defined?(Spree::TestingSupport::FactoryBot) &&
+          Spree::TestingSupport::FactoryBot.respond_to?(:definition_file_paths)
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR reflects the last changes we made in Solidus to support the new FactoryBot loading mechanism. 

We need to merge and release new versions of Solidus after https://github.com/solidusio/solidus/pull/3907, merge this PR and release a new version of `solidus_dev_support` to have the ecosystem working again with factories.  

When testing extensions using Solidus versions that support the `definition_file_paths`, it will load the core factory first
and then the ones defined in `lib/extension_name/testing_support/factories`. 

If the extension has a `lib/extension_name/testing_support/factories.rb` file that loads all the factories into `lib/extension_name/testing_support/factories/`, it should be removed now. If that happens this PR will make it print a deprecation warning telling users what to do. 

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- ~[ ] I have added relevant automated tests for this change.~
