### PR TITLE
Fix factories loading, part 2

### DIFF
--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -30,20 +30,37 @@ module SolidusDevSupport
     module Factories
       def self.load_for(*engines)
         paths = engines.flat_map do |engine|
-          factories_file_or_folder = engine.root.glob('lib/*/testing_support/factories{,.rb}')
-          if factories_file_or_folder.size == 2
-            folder, file = factories_file_or_folder.partition(&:directory?).map(&:first).map { |path| path.to_s.gsub(engine.root.to_s, '') }
+          # Check if the extension has a lib/*/factories.rb. If it does, we emit a
+          # deprecation warning and just use it.
+          obsolete_factories_file = engine.root.glob('lib/*/factories.rb').first # 'lib/*/factories/*_factory.rb'
+          if obsolete_factories_file.present?
             ActiveSupport::Deprecation.warn <<-WARN.squish, caller(4)
               SolidusDevSupport::TestingSupport::Factories.load_for() is automatically loading
-              all factories present into #{folder}. You should now safely remove #{file} if it
-              is only used to load ./factories content.
+              all factories present in #{obsolete_factories_file.dirname.to_s.gsub(engine.root.to_s, '')}/testing_support/factories/.
+              Please move the content of #{obsolete_factories_file.to_s.gsub(engine.root.to_s, '')} to that directory.
             WARN
 
-            engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
+            [obsolete_factories_file]
           else
-            factories_file_or_folder
-          end.map { |path| path.sub(/.rb\z/, '').to_s }
-        end
+            # If there are both a lib/*/testing_support/factories.rb and a lib/*/testing_support/factories/,
+            # we assume that the factories.rb file is only used to load all factories prensent in the directory.
+            # That file can be removed from the extension, in fact, we ignore it and emit a message asking to
+            # remove it.
+            factories_file_or_folder = engine.root.glob('lib/*/testing_support/factories{,.rb}')
+            if factories_file_or_folder.size == 2
+              folder, file = factories_file_or_folder.partition(&:directory?).map(&:first).map { |path| path.to_s.gsub(engine.root.to_s, '') }
+              ActiveSupport::Deprecation.warn <<-WARN.squish, caller(4)
+                SolidusDevSupport::TestingSupport::Factories.load_for() is automatically loading
+                all factories present into #{folder}. You should now safely remove #{file} if it
+                is only used to load ./factories content.
+              WARN
+
+              engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
+            else
+              factories_file_or_folder
+            end
+          end
+        end.map { |path| path.sub(/.rb\z/, '').to_s }
 
         if using_factory_bot_definition_file_paths?
           FactoryBot.definition_file_paths = [

--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -1,10 +1,28 @@
 # frozen_string_literal: true
 
+require 'factory_bot'
+
+Spree::Deprecation.silence do
+  require 'spree/testing_support/factories'
+  puts <<~MSG
+    We are transitioning to a new way of loading factories for extensions.
+    Be sure this extension does not load factories using require but uses
+    the load_for() method in its spec_helper.rb, eg:
+
+      SolidusDevSupport::TestingSupport::Factories.load_for(ExtensionName1::Engine, ExtensionName2::Engine)
+
+    This will load Solidus Core factories right before the ones defined in
+    lib/extension_name/testing_support/factories/*_factory.rb or
+    lib/extension_name/testing_support/factories.rb
+
+    This message will be removed when all extensions are updated.
+  MSG
+end
+
 begin
   require 'spree/testing_support/factory_bot'
 rescue LoadError
-  require 'factory_bot'
-  require 'spree/testing_support/factories'
+  # Do nothing, we are testing the extension against an old version of Solidus
 end
 
 module SolidusDevSupport

--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -13,8 +13,7 @@ module SolidusDevSupport
       def self.load_for(*engines)
         paths = engines.flat_map do |engine|
           factories_file_or_folder = engine.root.glob('lib/*/testing_support/factories{,.rb}')
-
-          if factories_file_or_folder.size == 2 && using_factory_bot_definition_file_paths?
+          if factories_file_or_folder.size == 2
             folder, file = factories_file_or_folder.partition(&:directory?).map(&:first).map { |path| path.to_s.gsub(engine.root.to_s, '') }
             ActiveSupport::Deprecation.warn <<-WARN.squish, caller(4)
               SolidusDevSupport::TestingSupport::Factories.load_for() is automatically loading


### PR DESCRIPTION
## Summary

Second round for #169. 

I released a new version this morning but I realized it's much more complex than I originally thought. 

This PR should cover all the main cases, I tested it with:
- `solidus_subscriptions`, `solidus_content`, `solidus_paypal_commece_platform`. All these extensions are loading factories in a different way, and they keep working, printing a good deprecation message with instructions about what to do. 
- all the extensions above, both Solidus v2.10 and Solidus v2.11. The former does not have the new code that uses `FactoryBot.definition_file_paths`, the latter does. 

Please, read commit by commit to have a detailed list of why things are changed this way.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- ~[ ] I have added relevant automated tests for this change.~
