### PR TITLE
Explode directories into individual files

### DIFF
--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -56,6 +56,8 @@ module SolidusDevSupport
               WARN
 
               engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
+            elsif factories_file_or_folder.first.directory?
+              engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
             else
               factories_file_or_folder
             end


### PR DESCRIPTION
## Summary

Without this, the directory is passed to require when `definition_file_paths` is not used. Ruby cannot require directories so it explodes.

Part 3 of #169  #170 

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- ~[ ] I have added relevant automated tests for this change.~
