### PR TITLE
Relax Ruby version requirement

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_dev_support'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_dev_support/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
-
+  spec.required_ruby_version = '>= 2.5.0'
+ 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   files = Dir.chdir(__dir__) { `git ls-files -z`.split("\x0") }

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_dev_support/blob/master/CHANGELOG.md'
 
   spec.required_ruby_version = '>= 2.5.0'
- 
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   files = Dir.chdir(__dir__) { `git ls-files -z`.split("\x0") }


### PR DESCRIPTION
This PR relaxes the Ruby version requirement to be `>= 2.5` considering we now have stable Ruby `3.x`

