### PR TITLE
Loosen webdrivers constraint in solidus_dev_support

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_dev_support'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_dev_support/blob/master/CHANGELOG.md'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.required_ruby_version = '>= 2.5.0'
 

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 2.0'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 4']
-  spec.add_dependency 'webdrivers', '~> 4.4'
+  spec.add_dependency 'webdrivers', '>= 4.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Goal
----

As a solidus_starter_frontend maintainer

I would like solidus_dev_support to support webdrivers 5.0

So that when solidus_starter_frontend is installed, it won't have to revert the
gem to an older version in order to support solidus_dev_support.

Expected criteria
-----------------

Given I have I installed a Solidus app following the instructions from https://github.com/nebulab/solidus_starter_frontend#for-a-new-store
When I check the `Gemfile.lock` file of the app
Then I should see that webdrivers has been set to 5.0.0.
When I try to install solidus_starter_frontend on top of the Solidus app (https://github.com/nebulab/solidus_starter_frontend#frontend-installation)
Then I should see that it is installed successfully

Bug description
---------------

When the solidus_starter_frontend script tries to install rspec, it
encounters the following error:

```
$ LOCATION="https://raw.githubusercontent.com/nebulab/solidus_starter_frontend/master/template.rb" bin/rails app:template

...

    generate  rspec:install
       rails  generate rspec:install
Bundler could not find compatible versions for gem "webdrivers":
  In snapshot (Gemfile.lock):
    webdrivers (= 5.0.0)

  In Gemfile:
    webdrivers

    solidus_dev_support (~> 2.5) was resolved to 2.5.1, which depends on
      webdrivers (~> 4.4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

Related
-------

See [Loosen puma and rspec-rails version constraints in solidus_dev_support](https://github.com/solidusio/solidus_dev_support/commit/48cb7abe37c9d9959c98506d4773eeb55140df61)
for a similar issue. You can also find the commit in
https://github.com/solidusio/solidus_dev_support/pull/178.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- N/A: I have added relevant automated tests for this change.
