### PR TITLE
Support newer versions of Selenium

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -9,12 +9,16 @@ Capybara.javascript_driver = (ENV['CAPYBARA_JAVASCRIPT_DRIVER'] || "solidus_chro
 Capybara.default_max_wait_time = 10
 Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
 
-Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
-  Capybara.register_driver :solidus_chrome_headless do |app|
-    original_driver.call(app).tap do |driver|
-      driver.options[:options].args << "--window-size=#{CAPYBARA_WINDOW_SIZE.join(',')}"
-    end
-  end
+chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |options|
+  options.add_argument("--window-size=#{CAPYBARA_WINDOW_SIZE.join(',')}")
+  options.add_argument("--headless")
+  options.add_argument("--disable-gpu")
+end
+
+options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+
+Capybara.register_driver :solidus_chrome_headless do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options_key => chrome_options)
 end
 
 require 'spree/testing_support/capybara_ext'

--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -15,6 +15,7 @@ chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |options|
   options.add_argument("--disable-gpu")
 end
 
+version = Capybara::Selenium::Driver.load_selenium
 options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
 
 Capybara.register_driver :solidus_chrome_headless do |app|

--- a/lib/solidus_dev_support/templates/extension/.circleci/config.yml
+++ b/lib/solidus_dev_support/templates/extension/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 orbs:
+  # Required for feature specs.
+  browser-tools: circleci/browser-tools@1.1
+
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
@@ -11,14 +14,17 @@ jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/lint-code
 
 workflows:


### PR DESCRIPTION
## Summary

After updating to `cimg/ruby:2.7-browsers`, we have a newer version of
Selenium running on CircleCI. As such, we need to define our
configuration in a way that is compatible with the new version.

This change is based on the example configuration provided here:
https://github.com/teamcapybara/capybara/blob/master/spec/selenium_spec_chrome.rb

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
