### PR TITLE
Fix window resizing of `solidus_chrome_headless` driver 

### DIFF
--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -13,7 +13,7 @@ module SolidusDevSupport
 
     def initialize(root: Dir.pwd)
       @root = Pathname(root)
-      @test_app_path = @root.join(ENV['DUMMY_PATH'] || 'spec/dummy')
+      @test_app_path = @root.join(ENV.fetch('DUMMY_PATH', 'spec/dummy'))
       @gemspec = Bundler.load_gemspec(@root.glob("{,*}.gemspec").first)
     end
 
@@ -43,7 +43,7 @@ module SolidusDevSupport
           cd root
         end
 
-        directory ENV['DUMMY_PATH'] do
+        directory ENV.fetch('DUMMY_PATH', nil) do
           Rake::Task['extension:test_app'].invoke
         end
       end
@@ -61,7 +61,7 @@ module SolidusDevSupport
       require 'rspec/core/rake_task'
 
       namespace :extension do
-        ::RSpec::Core::RakeTask.new(:specs, [] => FileList[ENV['DUMMY_PATH']]) do |t|
+        ::RSpec::Core::RakeTask.new(:specs, [] => FileList[ENV.fetch('DUMMY_PATH', nil)]) do |t|
           # Ref: https://circleci.com/docs/2.0/configuration-reference#store_test_results
           # Ref: https://github.com/solidusio/circleci-orbs-extensions#test-results-rspec
           if ENV['TEST_RESULTS_PATH']
@@ -82,7 +82,7 @@ module SolidusDevSupport
 
         config.user = repo.owner
         config.project = repo.name
-        config.future_release = "v#{ENV['UNRELEASED_VERSION'] || gemspec.version}"
+        config.future_release = "v#{ENV.fetch('UNRELEASED_VERSION') { gemspec.version }}"
 
       rescue Octokit::InvalidRepository
         warn <<~WARN

--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -4,6 +4,8 @@ require 'webdrivers/chromedriver'
 
 # Allow to override the initial windows size
 CAPYBARA_WINDOW_SIZE = ENV.fetch('CAPYBARA_WINDOW_SIZE', '1920x1080').split('x', 2).map(&:to_i)
+CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]
+CAPYBARA_WINDOW_HEIGHT = CAPYBARA_WINDOW_SIZE[1]
 
 Capybara.javascript_driver = ENV.fetch('CAPYBARA_JAVASCRIPT_DRIVER', "solidus_chrome_headless").to_sym
 Capybara.default_max_wait_time = 10
@@ -12,7 +14,9 @@ Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
 Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
   Capybara.register_driver :solidus_chrome_headless do |app|
     original_driver.call(app).tap do |driver|
-      driver.options[:options].args << "--window-size=#{CAPYBARA_WINDOW_SIZE.join(',')}"
+      driver.resize_window_to(
+        driver.current_window_handle, CAPYBARA_WINDOW_WIDTH, CAPYBARA_WINDOW_HEIGHT
+      )
     end
   end
 end

--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -3,9 +3,9 @@
 require 'webdrivers/chromedriver'
 
 # Allow to override the initial windows size
-CAPYBARA_WINDOW_SIZE = (ENV['CAPYBARA_WINDOW_SIZE'] || '1920x1080').split('x', 2).map(&:to_i)
+CAPYBARA_WINDOW_SIZE = ENV.fetch('CAPYBARA_WINDOW_SIZE', '1920x1080').split('x', 2).map(&:to_i)
 
-Capybara.javascript_driver = (ENV['CAPYBARA_JAVASCRIPT_DRIVER'] || "solidus_chrome_headless").to_sym
+Capybara.javascript_driver = ENV.fetch('CAPYBARA_JAVASCRIPT_DRIVER', "solidus_chrome_headless").to_sym
 Capybara.default_max_wait_time = 10
 Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
 

--- a/lib/solidus_dev_support/rspec/spec_helper.rb
+++ b/lib/solidus_dev_support/rspec/spec_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
   config.mock_with :rspec
   config.color = true
 
-  config.fail_fast = ENV['FAIL_FAST'] || false
+  config.fail_fast = ENV.fetch('FAIL_FAST', false)
   config.order = 'random'
 
   config.raise_errors_for_deprecations!

--- a/lib/solidus_dev_support/templates/extension/.circleci/config.yml
+++ b/lib/solidus_dev_support/templates/extension/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 orbs:
+  # Required for feature specs.
+  browser-tools: circleci/browser-tools@1.1
+
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
@@ -11,14 +14,17 @@ jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/lint-code
 
 workflows:

--- a/lib/solidus_dev_support/templates/extension/Gemfile
+++ b/lib/solidus_dev_support/templates/extension/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '>0.a'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-case ENV['DB']
+case ENV.fetch('DB', nil)
 when 'mysql'
   gem 'mysql2'
 when 'postgresql'


### PR DESCRIPTION
## Steps to reproduce

Run `bundle exec rspec` in SolidusAuthDevise.

## Expected behavior

Specs should pass.

## Actual behavior

Getting errors like this:

```
Failures:

  1) Checkout leaving and returning to address step
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: visit spree.root_path
          
          NoMethodError:
            undefined method `args' for nil:NilClass
          # ./spec/features/checkout_spec.rb:25:in `block (2 levels) in <top (required)>'
          # ./spec/support/confirm_helpers.rb:14:in `block (2 levels) in <top (required)>'
```

See https://app.circleci.com/pipelines/github/solidusio/solidus_auth_devise/338/workflows/ae0447ab-543d-47a6-8e72-be8afb94be4d/jobs/1356.

## Tests to confirm

I tested this SolidusDevSupport branch against SolidusAuthDevise. See:

* https://github.com/gsmendoza/solidus_auth_devise/tree/gsmendoza/eng-342-fix-window-resizing-of
* https://app.circleci.com/pipelines/github/gsmendoza/solidus_auth_devise/4/workflows/dfd0c390-f261-43d0-a307-d107dd497cf0

## Related PRs

This was based on https://github.com/solidusio/solidus_dev_support/pull/183.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
