### PR TITLE
Add a missing require for octokit/repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,11 @@ Style/RedundantRegexpEscape:
 Style/SlicingWithRange:
   Enabled: true
 
+# Disable this cop until this isssue gets a clear answer:
+# https://github.com/rubocop/rubocop/issues/10675
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: false
+
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:

--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -78,6 +78,7 @@ module SolidusDevSupport
 
       GitHubChangelogGenerator::RakeTask.new(:changelog) do |config|
         require 'octokit'
+        require 'octokit/repository'
         repo = Octokit::Repository.from_url(gemspec.metadata['source_code_uri'] || gemspec.homepage)
 
         config.user = repo.owner


### PR DESCRIPTION
## Summary

The Repository constant is not autoloaded nor eagerly loaded in
Octokit v4.23.

While running `rake clobber` (from `bin/setup`) on my copy of `solidus_subscription` the following error was shown:

```
⤑ bin/rake clobber --trace                                                                              ~/C/N/solidus_subscriptions
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
rake aborted!
NameError: uninitialized constant Octokit::Repository

        repo = Octokit::Repository.from_url(gemspec.metadata['source_code_uri'] || gemspec.homepage)
                      ^^^^^^^^^^^^
/Users/elia/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/solidus_dev_support-2.5.3/lib/solidus_dev_support/rake_tasks.rb:81:in `block in install_changelog_task'
/Users/elia/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/github_changelog_generator-1.16.4/lib/github_changelog_generator/task.rb:43:in `define'
/Users/elia/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/github_changelog_generator-1.16.4/lib/github_changelog_generator/task.rb:37:in `initialize'
/Users/elia/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/solidus_dev_support-2.5.3/lib/solidus_dev_support/rake_tasks.rb:79:in `new'
/Users/elia/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/solidus_dev_support-2.5.3/lib/solidus_dev_support/rake_tasks.rb:79:in `install_changelog_task'
/Users/elia/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/solidus_dev_support-2.5.3/lib/solidus_dev_support/rake_tasks.rb:26:in `install'
<internal:kernel>:90:in `tap'
…
```


## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
