### PR TITLE
Set Rails environment to test before invoking extension:test_app task

### DIFF
--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -44,6 +44,7 @@ module SolidusDevSupport
         end
 
         directory ENV.fetch('DUMMY_PATH', nil) do
+          ENV['RAILS_ENV'] = 'test'
           Rake::Task['extension:test_app'].invoke
         end
       end


### PR DESCRIPTION
This fixes the following error when running `bundle exec rake` in
SolidusPaypalCommercePlatform:

```
An error occurred in a `before(:suite)` hook.
Failure/Error: //= link spree/backend/all.js

Sprockets::FileNotFound:
  couldn't find file 'spree/backend/all.js'
  Checked in these paths:
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/config
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/images
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/stylesheets
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/javascripts
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/stylesheets
```

Cause
-----

`extension:specs`, the default rake task of SolidusPaypalCommercePlatform,
executes the rake tasks and Ruby methods below in the given order:

* The `extension` namespace defined in
  `SolidusDevSupport::RakeTasks#install_test_app_task`. This namespace invokes
  the `extension:test_app` task
  (https://github.com/solidusio/solidus_dev_support/blob/e5fec9c039607ab9e97c3f821cc49f9bbec08796/lib/solidus_dev_support/rake_tasks.rb#L47).

* The Solidus `extension:test_app` task
  (https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/lib/spree/testing_support/extension_rake.rb#L7)

* The `common:test_app` rake task in `CommonRakeTasks#initialize`
  (https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/lib/spree/testing_support/common_rake.rb#L14)

* `Solidus::InstallGenerator#setup_assets`
  (https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/lib/generators/solidus/install/install_generator.rb#L81)

The `setup_assets` method would only install the `all.*` frontend and backend
assets if either

* `Spree::Frontend` and `Spree::Backend` are loaded, or
* The Rails environment is test.

Currently, when we run `bundle exec rake` in SolidusPaypalCommercePlatform,
neither condition is met:

* `Spree::Frontend` and `Spree::Backend` are NOT loaded.
* The Rails environment is development.

Trigger
-------

This bug surfaced after we applied https://github.com/solidusio/solidus/pull/4251 (Fix: solidus:install adds the frontend
assets even if the repo does not have `solidus_frontend`).

Solution
--------

Considering that the `extension:test_app` rake task generates the
`spec/dummy` directory, we can assume that it is expected to run under
test environment.

## Testing

* [gsmendoza/eng-340-fix-soliduspaypalcommerceplatform-bundle--debug](https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/tree/gsmendoza/eng-340-fix-soliduspaypalcommerceplatform-bundle--debug) tests the fix against SolidusPaypalCommercePlatform. Here's the output of its `bundle exec rake` stripped off deprecation warnings and other noise: [2022-06-08-solidus-paypal-commerce-platform-output.txt](https://github.com/solidusio/solidus_dev_support/files/8860483/2022-06-08-solidus-paypal-commerce-platform-output.txt).

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
