### PR TITLE
Fix updating rubygems in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
       - run:
           name: "Update bundler"
           command: |
-            gem update --system
+            sudo gem update --system
             gem --version
             gem install bundler -v '>=2.3.21' --conservative
             bundle --version

--- a/lib/solidus_dev_support/rspec/feature_helper.rb
+++ b/lib/solidus_dev_support/rspec/feature_helper.rb
@@ -10,7 +10,7 @@
 require 'solidus_dev_support/rspec/rails_helper'
 require 'solidus_dev_support/rspec/capybara'
 
-def dev_support_assets_preload
+dev_support_assets_preload = ->(*) {
   if Rails.application.respond_to?(:precompiled_assets)
     Rails.application.precompiled_assets
   else
@@ -19,18 +19,14 @@ def dev_support_assets_preload
       Rails.application.assets.find_asset(asset)
     end
   end
-end
+}
 
 RSpec.configure do |config|
   config.when_first_matching_example_defined(type: :feature) do
-    config.before :suite do
-      dev_support_assets_preload
-    end
+    config.before :suite, &dev_support_assets_preload
   end
 
   config.when_first_matching_example_defined(type: :system) do
-    config.before :suite do
-      dev_support_assets_preload
-    end
+    config.before :suite, &dev_support_assets_preload
   end
 end

--- a/lib/solidus_dev_support/templates/extension/Gemfile
+++ b/lib/solidus_dev_support/templates/extension/Gemfile
@@ -27,6 +27,11 @@ else
   gem 'sqlite3'
 end
 
+# While we still support Ruby < 3 we need to workaround a limitation in
+# the 'async' gem that relies on the latest ruby, since RubyGems doesn't
+# resolve gems based on the required ruby version.
+gem 'async', '< 3' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
+
 gemspec
 
 # Use a local Gemfile to include development dependencies that might not be


### PR DESCRIPTION
## Summary

The `gem update --system` command is silently failing in the CI and a bunch of random failures seem to be tied to an older version of Rubygems.

In this case adding `sudo` is the correct solution on circleci docker images.

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [x] I have added relevant automated tests for this change.
