### PR TITLE
Configure solidus_chrome_headless as capybara-screenshot driver

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -21,4 +21,10 @@ Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
   end
 end
 
+require 'capybara-screenshot/rspec'
+
+Capybara::Screenshot.register_driver(:solidus_chrome_headless) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
 require 'spree/testing_support/capybara_ext'

--- a/lib/solidus_dev_support/rspec/feature_helper.rb
+++ b/lib/solidus_dev_support/rspec/feature_helper.rb
@@ -12,6 +12,10 @@ require 'solidus_dev_support/rspec/rails_helper'
 require 'capybara-screenshot/rspec'
 require 'solidus_dev_support/rspec/capybara'
 
+Capybara::Screenshot.register_driver(:solidus_chrome_headless) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
 def dev_support_assets_preload
   if Rails.application.respond_to?(:precompiled_assets)
     Rails.application.precompiled_assets

--- a/lib/solidus_dev_support/rspec/feature_helper.rb
+++ b/lib/solidus_dev_support/rspec/feature_helper.rb
@@ -8,13 +8,7 @@
 #
 
 require 'solidus_dev_support/rspec/rails_helper'
-
-require 'capybara-screenshot/rspec'
 require 'solidus_dev_support/rspec/capybara'
-
-Capybara::Screenshot.register_driver(:solidus_chrome_headless) do |driver, path|
-  driver.browser.save_screenshot(path)
-end
 
 def dev_support_assets_preload
   if Rails.application.respond_to?(:precompiled_assets)


### PR DESCRIPTION
We have a custom driver. Capybara-screenshot needs to know about it.

Should fix errors like this

<img width="" alt="Monosnap 2022-09-07 17-48-50" src="https://user-images.githubusercontent.com/42868/188922618-5cc11ce2-9624-44ee-8742-ac3bf15f4858.png">


## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.
