### PR TITLE
Fix sandbox default solidus branch

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-if [ ! -z $DEBUG ]
+if [ ! -z "$DEBUG" ]
 then
   set -x
 fi
@@ -28,7 +28,7 @@ sqlite3|sqlite)
 esac
 echo "~~> Using $RAILSDB as the database engine"
 
-if [ -n $SOLIDUS_BRANCH ]
+if [ -n "$SOLIDUS_BRANCH" ]
 then
   BRANCH=$SOLIDUS_BRANCH
 else
@@ -37,7 +37,7 @@ else
 fi
 echo "~~> Using branch $BRANCH of solidus"
 
-if [ -z $SOLIDUS_FRONTEND ]
+if [ -z "$SOLIDUS_FRONTEND" ]
 then
   echo "~~> Use 'export SOLIDUS_FRONTEND=[solidus_frontend|solidus_starter_frontend]' to control the Solidus frontend"
   SOLIDUS_FRONTEND="solidus_frontend"

--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-if [ ! -z "$DEBUG" ]
+if [ -n "$DEBUG" ]
 then
   set -x
 fi
@@ -28,14 +28,12 @@ sqlite3|sqlite)
 esac
 echo "~~> Using $RAILSDB as the database engine"
 
-if [ -n "$SOLIDUS_BRANCH" ]
+if [ -z "$SOLIDUS_BRANCH" ]
 then
-  BRANCH=$SOLIDUS_BRANCH
-else
   echo "~~> Use 'export SOLIDUS_BRANCH=[master|v3.2|...]' to control the Solidus branch"
-  BRANCH="master"
+  SOLIDUS_BRANCH="master"
 fi
-echo "~~> Using branch $BRANCH of solidus"
+echo "~~> Using branch $SOLIDUS_BRANCH of solidus"
 
 if [ -z "$SOLIDUS_FRONTEND" ]
 then
@@ -68,7 +66,7 @@ fi
 
 cd ./sandbox
 cat <<RUBY >> Gemfile
-gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
+gem 'solidus', github: 'solidusio/solidus', branch: '$SOLIDUS_BRANCH'
 gem 'rails-i18n'
 gem 'solidus_i18n'
 


### PR DESCRIPTION
Fixes the `sandbox.tt` file script not defaulting to the `master` Solidus when no `SOLIDUS_BRANCH` variable is given.

## Summary
When an uninitialized variable is given to `-n`, it is treated as not
NULL. The variable must be quoted for correct results.
`[ -n "$SOLIDUS_BRANCH" ]`

It is also recommended for variable comparisons in general as it can
produce incorrect results for `! -z`.

References:
- https://tldp.org/LDP/abs/html/comparison-ops.html
- https://tldp.org/LDP/abs/html/comparison-ops.html#STRTEST

This meant that before, when running this file with no SOLIDUS_BRANCH
variable, $BRANCH would end up NULL and the branch in the Gemfile would
be an empty string. This caused an error, whereas instead, it should
have defaulted to `master`.

Error:
```
fatal: Needed a single revision
Git error: command `git rev-parse --verify ''` in directory /Users/ryanwoods/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/cache/bundler/git/solidus-169f1ecb1aee2122950e6d586daf2410f62df66e has
failed.
Revision  does not exist in the repository https://github.com/solidusio/solidus.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory
'/Users/ryanwoods/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/cache/bundler/git/solidus-169f1ecb1aee2122950e6d586daf2410f62df66e'

The git source https://github.com/solidusio/solidus.git is not yet checked out. Please run `bundle install` before trying to start your application
```

## Checklist

- [x] I have structured the commits for clarity and conciseness.
- [ ] I have added relevant automated tests for this change.

To test this, I commented out half of the `sandbox.tt` file after (`extension_name="<%= file_name %>"`) and ran:
```sh
bash lib/solidus_dev_support/templates/extension/bin/sandbox.tt
```
It logged that the `master` branch was being used and `solidus_frontend` and no debug mode was used.

I then ran:
```sh
DEBUG=true SOLIDUS_BRANCH="v3.2" SOLIDUS_FRONTEND="solidus_starter_frontend" bash lib/solidus_dev_support/templates/extension/bin/sandbox.tt
```
Which logged that the `v.3.2` Solidus branch was being used and `solidus_starter_frontend` for the frontend 👍 It also correctly used the debug mode.
<img width="1728" alt="Screenshot 2022-11-09 at 10 19 50" src="https://user-images.githubusercontent.com/76776099/200795355-61c2efae-bccb-446d-8a13-48dca072094a.png">




