### PR TITLE
Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   # to change this configuration every time a Solidus version is released
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
+  slack: circleci/slack@4.9.3
 
 commands:
   setup:
@@ -19,27 +20,38 @@ commands:
             gem install bundler -v '>=2.3.21' --conservative
             bundle --version
 
+  notify:
+    steps:
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: master
+
 jobs:
   solidus-master:
     executor: solidusio_extensions/sqlite
-    steps: ['setup', 'solidusio_extensions/run-tests-solidus-master']
+    steps: ['setup', 'solidusio_extensions/run-tests-solidus-master', 'notify']
   solidus-current:
     executor: solidusio_extensions/sqlite
-    steps: ['setup', 'solidusio_extensions/run-tests-solidus-current']
+    steps: ['setup', 'solidusio_extensions/run-tests-solidus-current', 'notify']
   solidus-older:
     executor: solidusio_extensions/sqlite
-    steps: ['setup', 'solidusio_extensions/run-tests-solidus-older']
+    steps: ['setup', 'solidusio_extensions/run-tests-solidus-older', 'notify']
   lint-code:
     executor: solidusio_extensions/sqlite
-    steps: ['setup', 'solidusio_extensions/lint-code']
+    steps: ['setup', 'solidusio_extensions/lint-code', 'notify']
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - solidus-master
-      - solidus-current
-      - solidus-older
-      - lint-code
+      - solidus-master:
+          context: slack-secrets
+      - solidus-current:
+          context: slack-secrets
+      - solidus-older:
+          context: slack-secrets
+      - lint-code:
+          context: slack-secrets
 
   "Weekly run specs against master":
     triggers:
@@ -50,6 +62,9 @@ workflows:
               only:
                 - master
     jobs:
-      - solidus-master
-      - solidus-current
-      - solidus-older
+      - solidus-master:
+          context: slack-secrets
+      - solidus-current:
+          context: slack-secrets
+      - solidus-older:
+          context: slack-secrets


### PR DESCRIPTION
## Summary

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2)  channel on Solidus' [Slack workspace](https://soliidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202761161-c405a031-1277-407b-b721-0a9bc68e4acc.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
