### PR TITLE
Adapt to latest Solidus release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,11 @@ commands:
             bundle --version
 
 jobs:
-  solidus-master:
+  solidus-main:
     executor:
       name: solidusio_extensions/sqlite
       ruby_version: '3.1'
-    steps: ['setup', 'solidusio_extensions/run-tests-solidus-master']
+    steps: ['setup', 'solidusio_extensions/run-tests-solidus-main']
   solidus-current:
     executor:
       name: solidusio_extensions/sqlite
@@ -44,20 +44,20 @@ jobs:
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - solidus-master
+      - solidus-main
       - solidus-current
       - solidus-older
       - lint-code
 
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
-      - solidus-master
+      - solidus-main
       - solidus-current
       - solidus-older

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in solidus_dev_support.gemspec
 gemspec
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 # A workaround for https://github.com/bundler/bundler/issues/6677

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the `DB` and `SOLIDUS_BRANCH` env variables.
 DB=[postgres|mysql|sqlite] SOLIDUS_BRANCH=<BRANCH-NAME> bin/sandbox
 ```
 
-By default we use sqlite3 and the master branch.
+By default we use sqlite3 and the main branch.
 
 ### Rails generators
 

--- a/lib/solidus_dev_support/templates/extension/.circleci/config.yml
+++ b/lib/solidus_dev_support/templates/extension/.circleci/config.yml
@@ -39,14 +39,14 @@ workflows:
       - run-specs-with-mysql
       - lint-code
 
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - run-specs-with-sqlite
       - run-specs-with-postgres

--- a/lib/solidus_dev_support/templates/extension/Gemfile.tt
+++ b/lib/solidus_dev_support/templates/extension/Gemfile.tt
@@ -7,8 +7,13 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 # The solidus_frontend gem has been pulled out since v3.2
-gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'main'
-gem 'solidus_frontend' if branch >= 'v3.2' # rubocop:disable Bundler/DuplicatedGem
+if branch >= 'v3.2'
+  gem 'solidus_frontend'
+elsif branch == 'main'
+  gem 'solidus_frontend', github: 'solidusio/solidus_frontend'
+else
+  gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
+end
 
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.

--- a/lib/solidus_dev_support/templates/extension/Gemfile.tt
+++ b/lib/solidus_dev_support/templates/extension/Gemfile.tt
@@ -3,11 +3,11 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 # The solidus_frontend gem has been pulled out since v3.2
-gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'master'
+gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'main'
 gem 'solidus_frontend' if branch >= 'v3.2' # rubocop:disable Bundler/DuplicatedGem
 
 # Needed to help Bundler figure out how to resolve dependencies,

--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -7,8 +7,8 @@ test "$DB" = "sqlite" && export DB="sqlite3"
 
 if [ -z "$SOLIDUS_BRANCH" ]
 then
-  echo "~~> Use 'export SOLIDUS_BRANCH=[master|v3.2|...]' to control the Solidus branch"
-  SOLIDUS_BRANCH="master"
+  echo "~~> Use 'export SOLIDUS_BRANCH=[main|v3.2|...]' to control the Solidus branch"
+  SOLIDUS_BRANCH="main"
 fi
 echo "~~> Using branch $SOLIDUS_BRANCH of solidus"
 

--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support', '<%= SolidusDevSupport.gem_version.approximate_recommendation %>'


### PR DESCRIPTION
## Summary

Stop trying to pull solidus_frontend v4, which doesn't exist.

Adopt new Solidus default branch. Ref. https://github.com/solidusio/solidus/pull/5042

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
