### PR TITLE
Remove support for deprecated way of loading factories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,9 @@ jobs:
       ruby_version: '2.7'
     steps: ['setup', 'solidusio_extensions/run-tests-solidus-older']
   lint-code:
-    executor: solidusio_extensions/sqlite
+    executor:
+      name: solidusio_extensions/sqlite
+      ruby_version: '3.0'
     steps: ['setup', 'solidusio_extensions/lint-code']
 
 workflows:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 inherit_from:
   - https://relaxed.ruby.style/rubocop.yml
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 Layout/SpaceAroundMethodCallOperator:
@@ -42,7 +44,7 @@ Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   Exclude:
     - tmp/**/*
     - "vendor/**/*"
@@ -55,4 +57,3 @@ Style/FrozenStringLiteralComment:
     - "**/bin/*"
     - "**/exe/*"
     - "spec/**/*"
-

--- a/lib/solidus_dev_support/rubocop.rb
+++ b/lib/solidus_dev_support/rubocop.rb
@@ -2,7 +2,7 @@
 
 module SolidusDevSupport
   module RuboCop
-    CONFIG_PATH = "#{__dir__}/rubocop/config.yml"
+    CONFIG_PATH = "#{__dir__}/rubocop/config.yml".freeze
 
     def self.inject_defaults!
       config = ::RuboCop::ConfigLoader.load_file(CONFIG_PATH)

--- a/lib/solidus_dev_support/templates/extension/README.md
+++ b/lib/solidus_dev_support/templates/extension/README.md
@@ -42,14 +42,7 @@ bundle exec rubocop
 ```
 
 When testing your application's integration with this extension you may use its factories.
-Simply add this require statement to your `spec/spec_helper.rb`:
-
-```ruby
-require '<%= file_name %>/testing_support/factories'
-```
-
-Or, if you are using `FactoryBot.definition_file_paths`, you can load Solidus core
-factories along with this extension's factories using this statement:
+You can load Solidus core factories along with this extension's factories using this statement:
 
 ```ruby
 SolidusDevSupport::TestingSupport::Factories.load_for(<%= class_name %>::Engine)

--- a/lib/solidus_dev_support/templates/extension/spec/spec_helper.rb.tt
+++ b/lib/solidus_dev_support/templates/extension/spec/spec_helper.rb.tt
@@ -18,7 +18,8 @@ require 'solidus_dev_support/rspec/feature_helper'
 # in spec/support/ and its subdirectories.
 Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
-# Requires factories defined in lib/<%= file_name %>/testing_support/factories.rb
+# Requires factories defined in Solidus core and this extension.
+# See: lib/<%= file_name %>/testing_support/factories.rb
 SolidusDevSupport::TestingSupport::Factories.load_for(<%= class_name %>::Engine)
 
 RSpec.configure do |config|

--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -1,86 +1,22 @@
 # frozen_string_literal: true
 
 require 'factory_bot'
-
-Spree::Deprecation.silence do
-  require 'spree/testing_support/factories'
-  puts <<~MSG
-    We are transitioning to a new way of loading factories for extensions.
-    Be sure this extension does not load factories using require but uses
-    the load_for() method in its spec_helper.rb, eg:
-
-      SolidusDevSupport::TestingSupport::Factories.load_for(ExtensionName1::Engine, ExtensionName2::Engine)
-
-    This will load Solidus Core factories right before the ones defined in
-    lib/extension_name/testing_support/factories/*_factory.rb or
-    lib/extension_name/testing_support/factories.rb
-
-    This message will be removed when all extensions are updated.
-  MSG
-end
-
-begin
-  require 'spree/testing_support/factory_bot'
-rescue LoadError
-  # Do nothing, we are testing the extension against an old version of Solidus
-end
+require 'spree/testing_support/factory_bot'
 
 module SolidusDevSupport
   module TestingSupport
     module Factories
       def self.load_for(*engines)
         paths = engines.flat_map do |engine|
-          # Check if the extension has a lib/*/factories.rb. If it does, we emit a
-          # deprecation warning and just use it.
-          obsolete_factories_file = engine.root.glob('lib/*/factories.rb').first # 'lib/*/factories/*_factory.rb'
-          if obsolete_factories_file.present?
-            ActiveSupport::Deprecation.warn <<-WARN.squish, caller(4)
-              SolidusDevSupport::TestingSupport::Factories.load_for() is automatically loading
-              all factories present in #{obsolete_factories_file.dirname.to_s.gsub(engine.root.to_s, '')}/testing_support/factories/.
-              Please move the content of #{obsolete_factories_file.to_s.gsub(engine.root.to_s, '')} to that directory.
-            WARN
-
-            [obsolete_factories_file]
-          else
-            # If there are both a lib/*/testing_support/factories.rb and a lib/*/testing_support/factories/,
-            # we assume that the factories.rb file is only used to load all factories prensent in the directory.
-            # That file can be removed from the extension, in fact, we ignore it and emit a message asking to
-            # remove it.
-            factories_file_or_folder = engine.root.glob('lib/*/testing_support/factories{,.rb}')
-            if factories_file_or_folder.size == 2
-              folder, file = factories_file_or_folder.partition(&:directory?).map(&:first).map { |path| path.to_s.gsub(engine.root.to_s, '') }
-              ActiveSupport::Deprecation.warn <<-WARN.squish, caller(4)
-                SolidusDevSupport::TestingSupport::Factories.load_for() is automatically loading
-                all factories present into #{folder}. You should now safely remove #{file} if it
-                is only used to load ./factories content.
-              WARN
-
-              engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
-            elsif factories_file_or_folder.first.directory?
-              engine.root.glob('lib/*/testing_support/factories/**/*_factory.rb')
-            else
-              factories_file_or_folder
-            end
-          end
+          engine.root.glob('lib/*/testing_support/factories{,.rb}')
         end.map { |path| path.sub(/.rb\z/, '').to_s }
 
-        if using_factory_bot_definition_file_paths?
-          FactoryBot.definition_file_paths = [
-            Spree::TestingSupport::FactoryBot.definition_file_paths,
-            paths,
-          ].flatten
+        FactoryBot.definition_file_paths = [
+          Spree::TestingSupport::FactoryBot.definition_file_paths,
+          paths,
+        ].flatten
 
-          FactoryBot.reload
-        else
-          FactoryBot.find_definitions
-
-          paths.each { |path| require path }
-        end
-      end
-
-      def self.using_factory_bot_definition_file_paths?
-        defined?(Spree::TestingSupport::FactoryBot) &&
-          Spree::TestingSupport::FactoryBot.respond_to?(:definition_file_paths)
+        FactoryBot.reload
       end
     end
   end

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe 'Create extension' do
     if $DEBUG || ENV['DEBUG']
       warn '~' * 80
       warn "$ #{command}"
-      warn output.to_s
+      warn output
       warn "$ #{command} ~~~~> EXIT STATUS: #{status.exitstatus}"
     end
 


### PR DESCRIPTION
## Summary

Without this change, all the extensions will fail against Solidus v4.0 because the file `spree/testing_support/factories` that we always require no longer exists.

If any extension is still loading factories using `require` it should change to use `load_for` or will fail.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
