### PR TITLE
Allow loading of factories from namespaced extensions

### DIFF
--- a/lib/solidus_dev_support/testing_support/factories.rb
+++ b/lib/solidus_dev_support/testing_support/factories.rb
@@ -8,7 +8,7 @@ module SolidusDevSupport
     module Factories
       def self.load_for(*engines)
         paths = engines.flat_map do |engine|
-          engine.root.glob('lib/*/testing_support/factories{,.rb}')
+          engine.root.glob('lib/**/testing_support/factories{,.rb}')
         end.map { |path| path.sub(/.rb\z/, '').to_s }
 
         FactoryBot.definition_file_paths = [


### PR DESCRIPTION
## Summary

The previous glob did not allow there to be more than one level of namespacing in the extension file structure when loading factories.
This change will support extensions that have their factories in a folder structure like `lib/super_good/solidus_taxjar/testing_support/factories/*`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
