### PR TITLE
Update circle.ci configuration for branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,11 @@ commands:
             bundle --version
 
 jobs:
-  solidus-master:
+  solidus-main:
     executor:
       name: solidusio_extensions/sqlite
       ruby_version: '3.1'
-    steps: ['setup', 'solidusio_extensions/run-tests-solidus-master']
+    steps: ['setup', 'solidusio_extensions/run-tests-solidus-main']
   solidus-current:
     executor:
       name: solidusio_extensions/sqlite
@@ -44,7 +44,7 @@ jobs:
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - solidus-master
+      - solidus-main
       - solidus-current
       - solidus-older
       - lint-code
@@ -58,6 +58,6 @@ workflows:
               only:
                 - master
     jobs:
-      - solidus-master
+      - solidus-main
       - solidus-current
       - solidus-older


### PR DESCRIPTION
## Summary

Solidus' development branch is now called `main` and as a result the CI
Orb was updated with jobs to reflect that. This renames the workflow to
reflect the change in the Orb as well as renames the job define in this
config to reflect that.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
