### PR TITLE
Add Solidus Auth Devise to Sandbox script

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -47,6 +47,7 @@ cat <<RUBY >> Gemfile
 gem 'solidus', github: 'solidusio/solidus', branch: '$SOLIDUS_BRANCH'
 gem 'rails-i18n'
 gem 'solidus_i18n'
+gem 'solidus_auth_devise'
 
 gem '$extension_name', path: '..'
 


### PR DESCRIPTION
## Summary

Without adding the gem, the `rake solidus:auth:install` command further down the script will fail.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
