### PR TITLE
Adapt sandbox script to solidus 4

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -5,43 +5,45 @@ test -z "${DEBUG+empty_string}" || set -x
 
 test "$DB" = "sqlite" && export DB="sqlite3"
 
+if [ -z "$PAYMENT_METHOD" ]
+then
+  PAYMENT_METHOD="none"
+fi
+
 if [ -z "$SOLIDUS_BRANCH" ]
 then
-  echo "~~> Use 'export SOLIDUS_BRANCH=[main|v3.2|...]' to control the Solidus branch"
+  echo "~~> Use 'export SOLIDUS_BRANCH=[main|v4.0|...]' to control the Solidus branch"
   SOLIDUS_BRANCH="main"
 fi
 echo "~~> Using branch $SOLIDUS_BRANCH of solidus"
-
-if [ -z "$SOLIDUS_FRONTEND" ]
-then
-  echo "~~> Use 'export SOLIDUS_FRONTEND=[solidus_frontend|solidus_starter_frontend]' to control the Solidus frontend"
-  SOLIDUS_FRONTEND="solidus_frontend"
-fi
-echo "~~> Using branch $SOLIDUS_FRONTEND as the solidus frontend"
 
 extension_name="<%= file_name %>"
 
 # Stay away from the bundler env of the containing extension.
 function unbundled {
-  ruby -rbundler -e'b = proc {system *ARGV}; Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&b) : Bundler.with_clean_env(&b)' -- $@
+  ruby -rbundler -e'
+      Bundler.with_unbundled_env {system *ARGV}' -- \
+        env BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES=true $@
 }
 
+echo "~~~> Removing the old sandbox"
 rm -rf ./sandbox
-unbundled bundle exec rails new sandbox \
+
+echo "~~~> Creating a pristine Rails app"
+rails new sandbox \
   --database="${DB:-sqlite3}" \
-  --skip-bundle \
   --skip-git \
   --skip-keeps \
   --skip-rc \
-  --skip-spring \
-  --skip-test \
-  --skip-javascript
+  --skip-bootsnap \
+  --skip-test
 
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'
   exit 1
 fi
 
+echo "~~~> Adding solidus (with i18n) to the Gemfile"
 cd ./sandbox
 cat <<RUBY >> Gemfile
 gem 'solidus', github: 'solidusio/solidus', branch: '$SOLIDUS_BRANCH'
@@ -63,11 +65,6 @@ unbundled bundle exec rake db:drop db:create
 
 unbundled bundle exec rails generate solidus:install \
   --auto-accept \
-  --user_class=Spree::User \
-  --enforce_available_locales=true \
-  --with-authentication=<%= file_name != 'solidus_auth_devise' %> \
-  --payment-method=none \
-  --frontend=${SOLIDUS_FRONTEND} \
   $@
 
 unbundled bundle exec rails generate solidus:auth:install --auto-run-migrations


### PR DESCRIPTION
## Summary

The automatically generated `bin/sandbox` script does not work with current Solidus any longer. This upgrades the script to work with (at least) Solidus 4. 

It also provides a Rake task to help you obtain this script in existing extensions. From the root of your extension, run

```
bin/rake extension:upgrade_binstubs
```


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
