### PR TITLE
Remove dependency on the webdrivers gem

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'webdrivers/chromedriver'
-
 # Allow to override the initial windows size
 CAPYBARA_WINDOW_SIZE = ENV.fetch('CAPYBARA_WINDOW_SIZE', '1920x1080').split('x', 2).map(&:to_i)
 CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -45,6 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 2.0'
+  spec.add_dependency 'selenium-webdriver', '~> 4.11'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 5']
-  spec.add_dependency 'webdrivers', '>= 4.4'
 end


### PR DESCRIPTION
## Summary

The webdrivers gem no longer works with recent versions of Chrome. Recent versions of selenium-webdriver (newer than 4.11) achieve the same effect.

One caveat with this change: it implicitly requires Ruby 3 as that's the requirement for selenium-webdriver 4.11+.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
