### PR TITLE
Update `solidus-older` CI tasks to use Ruby 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
   solidus-older:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '2.7'
+      ruby_version: '3.0'
     steps: ['setup', 'solidusio_extensions/run-tests-solidus-older']
   lint-code:
     executor:

--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -83,7 +83,6 @@ module SolidusDevSupport
         config.user = repo.owner
         config.project = repo.name
         config.future_release = "v#{ENV.fetch('UNRELEASED_VERSION') { gemspec.version }}"
-
       rescue Octokit::InvalidRepository
         warn <<~WARN
           It won't be possible to automatically generate the CHANGELOG for this extension because the


### PR DESCRIPTION
## Summary

Ruby 2.7 has been end-of-lifed: https://endoflife.date/ruby.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

