### PR TITLE
Allow Puma 6

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ffaker', '~> 2.13'
   spec.add_dependency 'gem-release', '~> 2.1'
   spec.add_dependency 'github_changelog_generator', '~> 1.15'
-  spec.add_dependency 'puma', '>= 4.3', '< 6.0'
+  spec.add_dependency 'puma', '>= 4.3', '< 7.0'
   spec.add_dependency 'rspec_junit_formatter'
   spec.add_dependency 'rspec-rails', '>= 4.0.0.beta3', '< 6.0'
   spec.add_dependency 'rubocop', '~> 1.0'

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -173,11 +173,11 @@ RSpec.describe 'Create extension' do
     output.to_s
   end
 
-  def with_unbundled_env(&block)
+  def with_unbundled_env(...)
     if Bundler.respond_to?(:with_unbundled_env)
-      Bundler.with_unbundled_env(&block)
+      Bundler.with_unbundled_env(...)
     else
-      Bundler.with_clean_env(&block)
+      Bundler.with_clean_env(...)
     end
   end
 


### PR DESCRIPTION

## Summary

Puma 6 was disallowed in 2022, because back then Rails itself generated Gemfiles with `'puma', "< 6". This is not the case anymore, in fact, Rails comes with Rack 3 which instead is incompatible with Puma 5.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
