### PR TITLE
Allow rspec-rails 6

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'github_changelog_generator', '~> 1.15'
   spec.add_dependency 'puma', '>= 4.3', '< 7.0'
   spec.add_dependency 'rspec_junit_formatter'
-  spec.add_dependency 'rspec-rails', '>= 4.0.0.beta3', '< 6.0'
+  spec.add_dependency 'rspec-rails', '>= 5.0', '< 7.0'
   spec.add_dependency 'rubocop', '~> 1.0'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'


### PR DESCRIPTION


## Summary

rspec-rails < 6.0.2 is incompatible with Rails 7.1 because of stricter view path typecasting in Rails 7.1. This bug is fixed in rspec-rails 6.0.2. Without this, controller specs in extensions will break.

https://github.com/rspec/rspec-rails/pull/2631

## Checklist


The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
