### PR TITLE
Add `rspec-retry` dependency

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'puma', '>= 4.3', '< 7.0'
   spec.add_dependency 'rspec_junit_formatter'
   spec.add_dependency 'rspec-rails', '>= 5.0', '< 7.0'
+  spec.add_dependency 'rspec-retry'
   spec.add_dependency 'rubocop', '~> 1.0'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
   spec.add_dependency 'rubocop-rails', '~> 2.3'


### PR DESCRIPTION
Solidus core defines a spec helper module `spree/testing_support/flaky` which relies on `rspec-retry`. When using this from other gems, these gems have to know to require `rspec-retry`, even though they already have `solidus_dev_support`. I think it would be a good idea to just add it here instead of as a dev dependency on every extension that might have flaky specs.
