### PR TITLE
Restrict SQLite to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'mysql2'
   gem 'pg'
   gem 'solidus_auth_devise'
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 # Use a local Gemfile to include development dependencies that might not be

--- a/lib/solidus_dev_support/templates/extension/Gemfile.tt
+++ b/lib/solidus_dev_support/templates/extension/Gemfile.tt
@@ -30,7 +30,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 # While we still support Ruby < 3 we need to workaround a limitation in


### PR DESCRIPTION
They just released sqlite3 2.0.0, but ActiveRecord's sqlite3 adapter doesn't know about this yet, leading to conflicting sqlite3 gems in specs.

This is probably a temporary fix until ActiveRecord learns the news.

See https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14 and https://github.com/sparklemotion/sqlite3-ruby/blob/main/CHANGELOG.md
