### PR TITLE
Add tailwindcss-rails as runtime dep for solidus_dev_support

### DIFF
--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rspec', '~> 2.0'
   spec.add_dependency 'selenium-webdriver', '~> 4.11'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 5']
+  spec.add_dependency 'tailwindcss-rails', '~> 2.2'
 end


### PR DESCRIPTION
This way, all extensions will have tailwind as their dev dependency.
