### PR TITLE
Allow passing a user class to the test app generator

### DIFF
--- a/lib/solidus_dev_support/rake_tasks.rb
+++ b/lib/solidus_dev_support/rake_tasks.rb
@@ -7,14 +7,15 @@ module SolidusDevSupport
   class RakeTasks
     include Rake::DSL
 
-    def self.install(*args)
-      new(*args).tap(&:install)
+    def self.install(**args)
+      new(**args).tap(&:install)
     end
 
-    def initialize(root: Dir.pwd)
+    def initialize(root: Dir.pwd, user_class: "Spree::LegacyUser")
       @root = Pathname(root)
       @test_app_path = @root.join(ENV.fetch('DUMMY_PATH', 'spec/dummy'))
       @gemspec = Bundler.load_gemspec(@root.glob("{,*}.gemspec").first)
+      @user_class = user_class
     end
 
     attr_reader :test_app_path, :root, :gemspec
@@ -39,12 +40,12 @@ module SolidusDevSupport
         # We need to go back to the gem root since the upstream
         # extension:test_app changes the working directory to be the dummy app.
         task :test_app do
-          Rake::Task['extension:test_app'].invoke
+          Rake::Task['extension:test_app'].invoke(@user_class)
           cd root
         end
 
         directory ENV.fetch('DUMMY_PATH', nil) do
-          Rake::Task['extension:test_app'].invoke
+          Rake::Task['extension:test_app'].invoke(@user_class)
         end
       end
     end

--- a/lib/solidus_dev_support/templates/extension/Rakefile
+++ b/lib/solidus_dev_support/templates/extension/Rakefile
@@ -2,6 +2,6 @@
 
 require "bundler/gem_tasks"
 require 'solidus_dev_support/rake_tasks'
-SolidusDevSupport::RakeTasks.install
+SolidusDevSupport::RakeTasks.install(user_class: "Spree::User")
 
 task default: 'extension:specs'


### PR DESCRIPTION
Currently, solidus_auth_devise is tested with a dummy app that specifies `Spree::LegacyUser` in its `spree.rb initializer. That's not great, but there's no way of fixing it if the rake task install does not pass through the user class option.
