### PR TITLE
Extension generator: Do not always require solidus_auth_devise

### DIFF
--- a/lib/solidus_dev_support/templates/extension/Gemfile.tt
+++ b/lib/solidus_dev_support/templates/extension/Gemfile.tt
@@ -20,10 +20,6 @@ end
 # See https://github.com/bundler/bundler/issues/6677
 gem 'rails', '>0.a'
 
-<% if file_name != 'solidus_auth_devise' %>
-# Provides basic authentication functionality for testing parts of your engine
-gem 'solidus_auth_devise'
-<% end %>
 case ENV.fetch('DB', nil)
 when 'mysql'
   gem 'mysql2'

--- a/lib/solidus_dev_support/templates/extension/Rakefile
+++ b/lib/solidus_dev_support/templates/extension/Rakefile
@@ -2,6 +2,6 @@
 
 require "bundler/gem_tasks"
 require 'solidus_dev_support/rake_tasks'
-SolidusDevSupport::RakeTasks.install(user_class: "Spree::User")
+SolidusDevSupport::RakeTasks.install
 
 task default: 'extension:specs'


### PR DESCRIPTION
For integration specs, we can simply stub `spree_current_user` and `spree_user_signed_in?`. See https://github.com/solidusio-contrib/solidus_reviews/pull/122 for an example.
