### PR TITLE
Use at least solidus_support 0.12.0

### DIFF
--- a/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
+++ b/lib/solidus_dev_support/templates/extension/extension.gemspec.tt
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
-  spec.add_dependency 'solidus_support', '~> 0.5'
+  spec.add_dependency 'solidus_support', '>= 0.12.0'
 
   spec.add_development_dependency 'solidus_dev_support', '<%= SolidusDevSupport.gem_version.approximate_recommendation %>'
 end


### PR DESCRIPTION
solidus_support 0.11.0 introduced flickwerk for patch loading. Somehow this messes with the zeitwerk autoloader and things acting weird (inflections broken, wrong constant module nesting, etc.)

0.12.0 reverted flickwerk.
