### PR TITLE
Add support for new codecov uploader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :test do
   gem 'mysql2'
   gem 'pg'
   gem 'solidus_auth_devise'
-  gem 'sqlite3', '~> 1.4'
+  gem 'sqlite3', rails_version < '~> 7.2' ? '~> 1.4' : '~> 2.0'
 end
 
 # Use a local Gemfile to include development dependencies that might not be

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gemspec
 branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-# A workaround for https://github.com/bundler/bundler/issues/6677
-gem 'rails', '>0.a'
+rails_version = ENV.fetch("RAILS_VERSION", "~> 7.0")
+gem 'rails', rails_version
 
 gem 'bundler'
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,7 @@ end
 # Use a local Gemfile to include development dependencies that might not be
 # relevant for the project or for other contributors, e.g.: `gem 'pry-debug'`.
 eval_gemfile 'Gemfile-local' if File.exist? 'Gemfile-local'
+
+if rails_version == "~> 7.0"
+  gem 'concurrent-ruby', '< 1.3.5'
+end

--- a/README.md
+++ b/README.md
@@ -143,6 +143,33 @@ you need to do! If your setup is more complex, look at the
 [SimpleCov](https://github.com/colszowka/simplecov)
 and [codecov-ruby](https://github.com/codecov/codecov-ruby) docs.
 
+> [!WARNING]
+> The Codecov ruby uploader is deprecated.
+> Please use the Codecov CLI uploader to upload code coverage reports.
+> See https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader for more information on upgrading.
+
+#### Using GitHub Actions
+
+The recommended way to upload coverage reports to Codecov with GitHub Actions is to use the `solidusio/test-solidus-extension`
+workflow.
+
+```yaml
+jobs:
+  RSpec:
+    env:
+      CODECOV_COVERAGE_PATH: ./coverage/coverage.xml
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run extension tests
+        uses: solidusio/test-solidus-extension@main
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.CODECOV_COVERAGE_PATH }}
+```
+
 ### RuboCop configuration
 
 solidus_dev_support includes a default [RuboCop](https://github.com/rubocop-hq/rubocop)

--- a/lib/solidus_dev_support/rspec/coverage.rb
+++ b/lib/solidus_dev_support/rspec/coverage.rb
@@ -19,6 +19,14 @@ end
 if ENV['CODECOV_TOKEN']
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  warn <<~WARN
+    DEPRECATION WARNING: The Codecov ruby uploader is deprecated.
+    Please use the Codecov CLI uploader to upload code coverage reports.
+    See https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader for more information on upgrading.
+  WARN
+elsif ENV['CODECOV_COVERAGE_PATH']
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 else
-  warn "Provide a CODECOV_TOKEN environment variable to enable Codecov uploads"
+  warn "Provide a CODECOV_COVERAGE_PATH environment variable to enable Codecov uploads"
 end

--- a/lib/solidus_dev_support/templates/extension/Gemfile.tt
+++ b/lib/solidus_dev_support/templates/extension/Gemfile.tt
@@ -29,6 +29,10 @@ else
   gem 'sqlite3', '~> 1.4'
 end
 
+if rails_version == '~> 7.0'
+  gem 'concurrent-ruby', '< 1.3.5'
+end
+
 # While we still support Ruby < 3 we need to workaround a limitation in
 # the 'async' gem that relies on the latest ruby, since RubyGems doesn't
 # resolve gems based on the required ruby version.

--- a/lib/solidus_dev_support/templates/extension/Gemfile.tt
+++ b/lib/solidus_dev_support/templates/extension/Gemfile.tt
@@ -15,10 +15,8 @@ else
   gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
 end
 
-# Needed to help Bundler figure out how to resolve dependencies,
-# otherwise it takes forever to resolve them.
-# See https://github.com/bundler/bundler/issues/6677
-gem 'rails', '>0.a'
+rails_version = ENV.fetch('RAILS_VERSION', '~> 7.0')
+gem 'rails', rails_version
 
 case ENV.fetch('DB', nil)
 when 'mysql'
@@ -26,7 +24,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3', '~> 1.4'
+  gem 'sqlite3', rails_version < '~> 7.2' ? '~> 1.4' : '~> 2.0'
 end
 
 if rails_version == '~> 7.0'

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -46,5 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 2.0'
   spec.add_dependency 'selenium-webdriver', '~> 4.11'
+  spec.add_dependency 'simplecov-cobertura', '~> 2.1'
   spec.add_dependency 'solidus_core', ['>= 2.0', '< 5']
 end

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'Create extension' do
       output = sh('bundle exec rspec')
       expect(output).to include('loading test_extension factories')
       expect(output).to include('1 example, 0 failures')
-      expect(output).to include(ENV['CODECOV_TOKEN'] ? 'Coverage reports upload successfully' : 'Provide a CODECOV_TOKEN environment variable to enable Codecov uploads')
+      expect(output).to include(ENV['CODECOV_TOKEN'] ? 'Coverage reports upload successfully' : 'Provide a CODECOV_COVERAGE_PATH environment variable to enable Codecov uploads')
     end
   end
 


### PR DESCRIPTION
## Summary

The ruby codecov uploader gem is deprecated in favor of the codecov cli. There is a GitHub action that can be used to upload the coverage report.

Set the CODECOV_COVERAGE_PATH env var to use
the simplecov-cobertura formatter.

See: https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
