### PR TITLE
Generate Manifest file early in sandbox generation

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -61,6 +61,14 @@ group :test, :development do
 end
 RUBY
 
+echo "Generating manifest file"
+mkdir -p app/assets/config
+cat <<MANIFESTJS > app/assets/config/manifest.js
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+MANIFESTJS
+
 unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create


### PR DESCRIPTION

## Summary

The sandbox wants to install Solidus and migrate before running the install generator. That's bad, because migrating requires the app to boot, and booting fails because Sprockets fails with an error if the `manifest.js` file is not present.

Since the file is quite simple, we can just pass it into a heredoc. This is needed for Rails 8, where the install generator won't create the file for us.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
