### PR TITLE
Rubocop config: Use plugins for rubocop-rails and rubocop-performance

### DIFF
--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -3,7 +3,9 @@ plugins:
   - rubocop-rails
   - rubocop-rspec
 
-AllCops: {TargetRubyVersion: 2.5, Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"]}
+AllCops:
+  TargetRubyVersion: 3.0
+  Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"]}
 
 Layout/ArgumentAlignment: {EnforcedStyle: with_fixed_indentation}
 Layout/DotPosition: {Enabled: false, StyleGuide: "https://relaxed.ruby.style/#layoutdotposition"}

--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -1,4 +1,7 @@
-require: ["rubocop-rspec", "rubocop-rails", "rubocop-performance"]
+plugins:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
 
 AllCops: {TargetRubyVersion: 2.5, Exclude: ["spec/dummy/**/*", "sandbox/**/*", "vendor/**/*"]}
 


### PR DESCRIPTION
Since Rubocop 1.72, we have to use plugins instead of require.
