### PR TITLE
Rubocop: Ignore bin/

### DIFF
--- a/lib/solidus_dev_support/rubocop/config.yml
+++ b/lib/solidus_dev_support/rubocop/config.yml
@@ -10,3 +10,4 @@ AllCops:
     - spec/dummy/**/*
     - sandbox/**/*
     - vendor/**/*
+    - bin/*


### PR DESCRIPTION
standardrb ignores the bin/ directory by default, so we do that, too. See: https://github.com/standardrb/standard/blob/main/lib/standard/creates_config_store/configures_ignored_paths.rb#L9
