### PR TITLE
Use core's capybara driver configuration

### DIFF
--- a/lib/solidus_dev_support/rspec/capybara.rb
+++ b/lib/solidus_dev_support/rspec/capybara.rb
@@ -1,28 +1,32 @@
 # frozen_string_literal: true
 
-# Allow to override the initial windows size
-CAPYBARA_WINDOW_SIZE = ENV.fetch("CAPYBARA_WINDOW_SIZE", "1920x1080").split("x", 2).map(&:to_i)
-CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]
-CAPYBARA_WINDOW_HEIGHT = CAPYBARA_WINDOW_SIZE[1]
+begin
+  require "spree/testing_support/capybara_driver"
+rescue LoadError
+  # Allow to override the initial windows size
+  CAPYBARA_WINDOW_SIZE = ENV.fetch("CAPYBARA_WINDOW_SIZE", "1920x1080").split("x", 2).map(&:to_i)
+  CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]
+  CAPYBARA_WINDOW_HEIGHT = CAPYBARA_WINDOW_SIZE[1]
 
-Capybara.javascript_driver = ENV.fetch("CAPYBARA_JAVASCRIPT_DRIVER", "solidus_chrome_headless").to_sym
-Capybara.default_max_wait_time = 10
-Capybara.server = :puma, {Silent: true} # A fix for rspec/rspec-rails#1897
+  Capybara.javascript_driver = ENV.fetch("CAPYBARA_JAVASCRIPT_DRIVER", "solidus_chrome_headless").to_sym
+  Capybara.default_max_wait_time = 10
+  Capybara.server = :puma, {Silent: true} # A fix for rspec/rspec-rails#1897
 
-Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
-  Capybara.register_driver :solidus_chrome_headless do |app|
-    original_driver.call(app).tap do |driver|
-      driver.resize_window_to(
-        driver.current_window_handle, CAPYBARA_WINDOW_WIDTH, CAPYBARA_WINDOW_HEIGHT
-      )
+  Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
+    Capybara.register_driver :solidus_chrome_headless do |app|
+      original_driver.call(app).tap do |driver|
+        driver.resize_window_to(
+          driver.current_window_handle, CAPYBARA_WINDOW_WIDTH, CAPYBARA_WINDOW_HEIGHT
+        )
+      end
     end
   end
-end
 
-require "capybara-screenshot/rspec"
+  require "capybara-screenshot/rspec"
 
-Capybara::Screenshot.register_driver(:solidus_chrome_headless) do |driver, path|
-  driver.browser.save_screenshot(path)
+  Capybara::Screenshot.register_driver(:solidus_chrome_headless) do |driver, path|
+    driver.browser.save_screenshot(path)
+  end
 end
 
 require "spree/testing_support/capybara_ext"


### PR DESCRIPTION

## Summary
Solidus core has migrated to using Firefox for headless testing, which seems to be more stable than Chrome, and uses minimal configuration.

See https://github.com/solidusio/solidus/pull/6230


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
