### PR TITLE
Update rspec-rails versions and fix tests

### DIFF
--- a/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
+++ b/lib/solidus_dev_support/templates/extension/bin/sandbox.tt
@@ -31,7 +31,7 @@ rm -rf ./sandbox
 
 echo "~~~> Creating a pristine Rails app"
 rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new sandbox \
+unbundled bundle exec rails _${rails_version}_ new sandbox \
   --database="${DB:-sqlite3}" \
   --skip-git \
   --skip-keeps \

--- a/solidus_dev_support.gemspec
+++ b/solidus_dev_support.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "github_changelog_generator", "~> 1.15"
   spec.add_dependency "puma", ">= 4.3", "< 7.0"
   spec.add_dependency "rspec_junit_formatter"
-  spec.add_dependency "rspec-rails", ">= 5.0", "< 7.0"
+  spec.add_dependency "rspec-rails", ">= 6.0", "< 9.0"
   spec.add_dependency "selenium-webdriver", "~> 4.11"
   spec.add_dependency "simplecov-cobertura", "~> 2.1"
   spec.add_dependency "solidus_core", [">= 2.0", "< 5"]

--- a/spec/features/create_extension_spec.rb
+++ b/spec/features/create_extension_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe "Create extension" do
   def check_default_task
     cd(install_path) do
       output = sh("bin/rake")
-      expect(output).to include("Generating dummy Rails application")
       expect(output).to include("0 examples, 0 failures")
     end
   end


### PR DESCRIPTION
## Summary

The versions we were requiring of rspec-rails did not match up with the current versions of Rails that are under test for this gem so I updated rspec-rails versions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
