### PR TITLE
Switch to reusable GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,29 @@ jobs:
             rails-version: "8.0"
           - solidus-branch: "v4.4"
             rails-version: "8.0"
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 5432:5432
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 3306:3306
     steps:
       - uses: actions/checkout@v4
       - name: Run extension tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
           - "mysql"
           - "sqlite"
         exclude:
+          - solidus-branch: "main"
+            ruby-version: "3.1"
           - rails-version: "7.2"
             solidus-branch: "v4.3"
           - ruby-version: "3.1"

--- a/lib/solidus_dev_support/extension.rb
+++ b/lib/solidus_dev_support/extension.rb
@@ -8,6 +8,7 @@ require "solidus_dev_support/version"
 module SolidusDevSupport
   class Extension < Thor
     include Thor::Actions
+
     PREFIX = "solidus_"
 
     default_command :generate

--- a/lib/solidus_dev_support/templates/extension/.github/workflows/test.yml
+++ b/lib/solidus_dev_support/templates/extension/.github/workflows/test.yml
@@ -7,65 +7,11 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * 4" # every Thursday
-
-concurrency:
-  group: test-${{ github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
   rspec:
-    name: Solidus ${{ matrix.solidus-branch }}, Rails ${{ matrix.rails-version }} and Ruby ${{ matrix.ruby-version }} on ${{ matrix.database }}
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: true
-      matrix:
-        rails-version:
-          - "7.0"
-          - "7.1"
-          - "7.2"
-        ruby-version:
-          - "3.1"
-          - "3.4"
-        solidus-branch:
-          - "v4.1"
-          - "v4.2"
-          - "v4.3"
-          - "v4.4"
-          - "v4.5"
-        database:
-          - "postgresql"
-          - "mysql"
-          - "sqlite"
-        exclude:
-          - rails-version: "7.2"
-            solidus-branch: "v4.3"
-          - rails-version: "7.2"
-            solidus-branch: "v4.2"
-          - rails-version: "7.2"
-            solidus-branch: "v4.1"
-          - rails-version: "7.1"
-            solidus-branch: "v4.2"
-          - rails-version: "7.1"
-            solidus-branch: "v4.1"
-          - ruby-version: "3.4"
-            rails-version: "7.0"
-    env:
-      CODECOV_COVERAGE_PATH: ./coverage/coverage.xml
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run extension tests
-        uses: solidusio/test-solidus-extension@main
-        with:
-          database: ${{ matrix.database }}
-          rails-version: ${{ matrix.rails-version }}
-          ruby-version: ${{ matrix.ruby-version }}
-          solidus-branch: ${{ matrix.solidus-branch }}
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        continue-on-error: true
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ env.CODECOV_COVERAGE_PATH }}
+    uses: solidusio/test-solidus-extension/.github/workflows/test.yml@main


### PR DESCRIPTION
## Summary

This changes the template in solidus_dev_support so that extensions will use the reusable workflow in test-solidus-extension.

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

